### PR TITLE
add options to load() to resolve recursiveDelete() issue

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -153,7 +153,11 @@ export class SolidLogic {
     }
     // force = true to reload the doc
     // but first remove doc: this is to avoid just adding quads
-    if (options && options.force) this.store.removeDocument(doc as NamedNode)
+    if (options && options.force) {
+      let removeDoc: any[] = [doc].flat()
+      if (typeof doc === 'string') removeDoc = [this.store.sym(doc as string)]
+      removeDoc.forEach(item => this.store.removeDocument(item as NamedNode))
+    }
     return this.store.fetcher.load(doc, options)
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,7 +69,7 @@ export class SolidLogic {
 
   async findAclDocUrl (url: string) {
     const doc = this.store.sym(url)
-    await this.load(doc, { force: true })
+    await this.load(doc)
     const docNode = this.store.any(doc, ACL_LINK)
     if (!docNode) {
       throw new Error(`No ACL link discovered for ${url}`);
@@ -190,18 +190,11 @@ export class SolidLogic {
       });
   }
 
-  load (doc: NamedNode | NamedNode[] | string, options?: any) {
+  load (doc: NamedNode | NamedNode[] | string) {
     if (!this.store.fetcher) {
       throw new Error("Cannot load doc(s), have no fetcher");
     }
-    // force = true to reload the doc
-    // but first remove doc: this is to avoid just adding quads
-    if (options && options.force) {
-      let removeDoc: any[] = [doc].flat()
-      if (typeof doc === 'string') removeDoc = [this.store.sym(doc as string)]
-      removeDoc.forEach(item => this.store.removeDocument(item as NamedNode))
-    }
-    return this.store.fetcher.load(doc, options)
+    return this.store.fetcher.load(doc)
   }
 
   async loadIndexes(
@@ -290,7 +283,8 @@ export class SolidLogic {
   }
 
   async getContainerMembers(containerUrl) {
-    await this.load(this.store.sym(containerUrl), { force: true })
+    // update to latest index.ttl content
+    await this.store.fetcher.refresh(this.store.sym(containerUrl))
     return this.store.statementsMatching(this.store.sym(containerUrl), this.store.sym('http://www.w3.org/ns/ldp#contains')).map((st: Statement) => st.object.value);
   }
 


### PR DESCRIPTION
1. this.store.fetcher.load(doc) with no options reuse the existing document in store.
This is not what we expect. We want load a new document.
options.force = true reload the document but adds new triples
we neee to remove the document from store in that case

2. force = true is used in aclDocUrl() and getContainerMembers().
@michielbdejong Should it be a default for load() ?

3. solid spec implies that delete is atomic (delete ressource and auxiliary one in the same operation)
I remove the acl delete in recursiveDelete()