### PR TITLE
replaced inrupt.net with solidweb.me

### DIFF
--- a/src/issuer/issuerLogic.ts
+++ b/src/issuer/issuerLogic.ts
@@ -8,11 +8,11 @@ const DEFAULT_ISSUERS = [
     uri: 'https://solidweb.org'
   },
   {
-    name: 'Inrupt.net',
-    uri: 'https://inrupt.net'
+    name: 'Solid Web ME',
+    uri: 'https://solidweb.me'
   },
   {
-    name: 'pod.Inrupt.com',
+    name: 'Inrupt.com',
     uri: 'https://login.inrupt.com'
   }
 ]


### PR DESCRIPTION
Inrupt.net does not exist anymore and solidweb.org is on NSS so I added solidweb.me which is on CSS
see reported issue: https://github.com/SolidOS/solid-logic/issues/102