### PR TITLE
Create settings files like server if they don't exist

### DIFF
--- a/src/profile/profileAclDocuments.ts
+++ b/src/profile/profileAclDocuments.ts
@@ -1,0 +1,12 @@
+export function ownerOnlyContainerAclDocument(webId: string): string {
+    return [
+        '@prefix acl: <http://www.w3.org/ns/auth/acl#>.',
+        '',
+        '<#owner>',
+        'a acl:Authorization;',
+        `acl:agent <${webId}>;`,
+        'acl:accessTo <./>;',
+        'acl:default <./>;',
+        'acl:mode acl:Read, acl:Write, acl:Control.'
+    ].join('\n')
+}

--- a/src/profile/profileDocuments.ts
+++ b/src/profile/profileDocuments.ts
@@ -1,0 +1,9 @@
+export function preferencesFileDocument(): string {
+    return [
+        '@prefix dct: <http://purl.org/dc/terms/>.',
+        '@prefix pim: <http://www.w3.org/ns/pim/space#>.',
+        '<>',
+        '    a pim:ConfigurationFile ;',
+        '    dct:title "Preferences file".'
+    ].join('\n')
+}

--- a/src/profile/profileDocuments.ts
+++ b/src/profile/profileDocuments.ts
@@ -2,6 +2,7 @@ export function preferencesFileDocument(): string {
     return [
         '@prefix dct: <http://purl.org/dc/terms/>.',
         '@prefix pim: <http://www.w3.org/ns/pim/space#>.',
+        '@prefix solid: <http://www.w3.org/ns/solid/terms#>.',
         '<>',
         '    a pim:ConfigurationFile ;',
         '    dct:title "Preferences file".'

--- a/src/profile/profileLogic.ts
+++ b/src/profile/profileLogic.ts
@@ -81,6 +81,15 @@ export function createProfileLogic(store, authn, utilityLogic): ProfileLogic {
         ].join('\n')
     }
 
+    function privateTypeIndexDocument(): string {
+        return [
+            '@prefix solid: <http://www.w3.org/ns/solid/terms#>.',
+            '<>',
+            '    a solid:TypeIndex ;',
+            '    a solid:UnlistedDocument.'
+        ].join('\n')
+    }
+
     async function ensureContainerExists(containerUri: string): Promise<void> {
         const containerNode = sym(containerUri)
         try {
@@ -170,6 +179,21 @@ export function createProfileLogic(store, authn, utilityLogic): ProfileLogic {
         })
     }
 
+    async function ensurePrivateTypeIndexOnCreate(privateTypeIndex: NamedNode): Promise<void> {
+        try {
+            await store.fetcher.load(privateTypeIndex)
+            return
+        } catch (err) {
+            if (!isNotFoundError(err)) throw err
+        }
+
+        await store.fetcher.webOperation('PUT', privateTypeIndex.uri, {
+            data: privateTypeIndexDocument(),
+            contentType: 'text/turtle'
+        })
+        await store.fetcher.load(privateTypeIndex)
+    }
+
     async function initializePreferencesDefaults(user: NamedNode, preferencesFile: NamedNode): Promise<void> {
         const preferencesDoc = preferencesFile.doc() as NamedNode
         const profileDoc = user.doc() as NamedNode
@@ -213,7 +237,7 @@ export function createProfileLogic(store, authn, utilityLogic): ProfileLogic {
         }
 
         await ensurePublicTypeIndexAclOnCreate(user, publicTypeIndex, createdProfilePublicTypeIndexLink)
-        await utilityLogic.loadOrCreateIfNotExists(privateTypeIndex)
+        await ensurePrivateTypeIndexOnCreate(privateTypeIndex)
     }
 
     async function ensurePreferencesDocExists(preferencesFile: NamedNode): Promise<boolean> {

--- a/src/profile/profileLogic.ts
+++ b/src/profile/profileLogic.ts
@@ -188,8 +188,13 @@ export function createProfileLogic(store, authn, utilityLogic): ProfileLogic {
         // Keep discovery consistent with typeIndexLogic, which resolves publicTypeIndex from the profile doc.
         const createdProfilePublicTypeIndexLink = !profilePublicTypeIndex
         if (createdProfilePublicTypeIndexLink) {
-            await utilityLogic.loadOrCreateWithContentOnCreate(publicTypeIndex, publicTypeIndexDocument())
-            await utilityLogic.followOrCreateLink(user, ns.solid('publicTypeIndex') as NamedNode, publicTypeIndex, profileDoc)
+            await utilityLogic.followOrCreateLinkWithContentOnCreate(
+                user,
+                ns.solid('publicTypeIndex') as NamedNode,
+                publicTypeIndex,
+                profileDoc,
+                publicTypeIndexDocument()
+            )
         }
 
         const toInsert: any[] = []

--- a/src/profile/profileLogic.ts
+++ b/src/profile/profileLogic.ts
@@ -1,4 +1,4 @@
-import { NamedNode } from 'rdflib'
+import { literal, NamedNode, st, sym } from 'rdflib'
 import { CrossOriginForbiddenError, FetchError, NotEditableError, SameOriginForbiddenError, UnauthorizedError, WebOperationError } from '../logic/CustomError'
 import * as debug from '../util/debug'
 import { ns as namespace } from '../util/ns'
@@ -7,6 +7,85 @@ import { ProfileLogic } from '../types'
 
 export function createProfileLogic(store, authn, utilityLogic): ProfileLogic {
     const ns = namespace
+
+    function isAbsoluteHttpUri(uri: string | null | undefined): boolean {
+        return !!uri && (uri.startsWith('https://') || uri.startsWith('http://'))
+    }
+
+    function docDirUri(node: NamedNode): string | null {
+        const doc = node.doc()
+        const dir = doc.dir()
+        if (dir?.uri && isAbsoluteHttpUri(dir.uri)) return dir.uri
+        const docUri = doc.uri
+        if (!docUri || !isAbsoluteHttpUri(docUri)) return null
+        const withoutFragment = docUri.split('#')[0]
+        const lastSlash = withoutFragment.lastIndexOf('/')
+        if (lastSlash === -1) return null
+        return withoutFragment.slice(0, lastSlash + 1)
+    }
+
+    function suggestTypeIndexInPreferences(preferencesFile: NamedNode, filename: string): NamedNode {
+        const dirUri = docDirUri(preferencesFile)
+        if (!dirUri) throw new Error(`Cannot derive directory for preferences file ${preferencesFile.uri}`)
+        return sym(dirUri + filename)
+    }
+
+    async function initializePreferencesDefaults(user: NamedNode, preferencesFile: NamedNode): Promise<void> {
+        const preferencesDoc = preferencesFile.doc() as NamedNode
+        await store.fetcher.load(preferencesDoc)
+
+        const publicTypeIndex =
+            (store.any(user, ns.solid('publicTypeIndex'), null, preferencesDoc) as NamedNode | null) ||
+            (store.any(user, ns.solid('publicTypeIndex'), null, user.doc()) as NamedNode | null) ||
+            suggestTypeIndexInPreferences(preferencesFile, 'publicTypeIndex.ttl')
+        const privateTypeIndex =
+            (store.any(user, ns.solid('privateTypeIndex'), null, preferencesDoc) as NamedNode | null) ||
+            suggestTypeIndexInPreferences(preferencesFile, 'privateTypeIndex.ttl')
+
+        const toInsert: any[] = []
+        if (!store.holds(preferencesDoc, ns.rdf('type'), ns.space('ConfigurationFile'), preferencesDoc)) {
+            toInsert.push(st(preferencesDoc, ns.rdf('type'), ns.space('ConfigurationFile'), preferencesDoc))
+        }
+        if (!store.holds(preferencesDoc, ns.dct('title'), undefined, preferencesDoc)) {
+            toInsert.push(st(preferencesDoc, ns.dct('title'), literal('Preferences file'), preferencesDoc))
+        }
+        if (!store.holds(user, ns.solid('publicTypeIndex'), publicTypeIndex, preferencesDoc)) {
+            toInsert.push(st(user, ns.solid('publicTypeIndex'), publicTypeIndex, preferencesDoc))
+        }
+        if (!store.holds(user, ns.solid('privateTypeIndex'), privateTypeIndex, preferencesDoc)) {
+            toInsert.push(st(user, ns.solid('privateTypeIndex'), privateTypeIndex, preferencesDoc))
+        }
+
+        if (toInsert.length > 0) {
+            await store.updater.update([], toInsert)
+            await store.fetcher.load(preferencesDoc)
+        }
+
+        await utilityLogic.loadOrCreateIfNotExists(publicTypeIndex)
+        await utilityLogic.loadOrCreateIfNotExists(privateTypeIndex)
+    }
+
+    async function ensurePreferencesDocExists(preferencesFile: NamedNode): Promise<boolean> {
+        try {
+            await store.fetcher.load(preferencesFile)
+            return false
+        } catch (err) {
+            if (err.response?.status === 404) {
+                await utilityLogic.loadOrCreateIfNotExists(preferencesFile)
+                return true
+            }
+            if (err.response?.status === 401) {
+                throw new UnauthorizedError()
+            }
+            if (err.response?.status === 403) {
+                if (differentOrigin(preferencesFile)) {
+                    throw new CrossOriginForbiddenError()
+                }
+                throw new SameOriginForbiddenError()
+            }
+            throw err
+        }
+    }
 
     /**
      * loads the preference without throwing errors - if it can create it it does so.
@@ -34,7 +113,17 @@ export function createProfileLogic(store, authn, utilityLogic): ProfileLogic {
         const possiblePreferencesFile = suggestPreferencesFile(user)
         let preferencesFile
         try {
-            preferencesFile = await utilityLogic.followOrCreateLink(user, ns.space('preferencesFile') as NamedNode, possiblePreferencesFile, user.doc())
+            const existingPreferencesFile = store.any(user, ns.space('preferencesFile'), null, user.doc()) as NamedNode | null
+            if (existingPreferencesFile) {
+                preferencesFile = existingPreferencesFile
+            } else {
+                preferencesFile = await utilityLogic.followOrCreateLink(user, ns.space('preferencesFile') as NamedNode, possiblePreferencesFile, user.doc())
+            }
+
+            const createdOrRepairedPreferencesDoc = await ensurePreferencesDocExists(preferencesFile as NamedNode)
+            if (!existingPreferencesFile || createdOrRepairedPreferencesDoc) {
+                await initializePreferencesDefaults(user, preferencesFile as NamedNode)
+            }
         } catch (err) {
             const message = `User ${user} has no pointer in profile to preferences file.`
             debug.warn(message)

--- a/src/profile/profileLogic.ts
+++ b/src/profile/profileLogic.ts
@@ -134,7 +134,7 @@ export function createProfileLogic(store, authn, utilityLogic): ProfileLogic {
         })
     }
 
-    async function ensurePublicTypeIndexAclOnCreate(user: NamedNode, publicTypeIndex: NamedNode): Promise<void> {
+    async function ensurePublicTypeIndexAclOnCreate(user: NamedNode, publicTypeIndex: NamedNode, ensureAcl = false): Promise<void> {
         let created = false
         try {
             await store.fetcher.load(publicTypeIndex)
@@ -143,7 +143,7 @@ export function createProfileLogic(store, authn, utilityLogic): ProfileLogic {
             await utilityLogic.loadOrCreateIfNotExists(publicTypeIndex)
             created = true
         }
-        if (!created) return
+        if (!created && !ensureAcl) return
 
         let aclDocUri: string | undefined
         try {
@@ -172,15 +172,26 @@ export function createProfileLogic(store, authn, utilityLogic): ProfileLogic {
 
     async function initializePreferencesDefaults(user: NamedNode, preferencesFile: NamedNode): Promise<void> {
         const preferencesDoc = preferencesFile.doc() as NamedNode
+        const profileDoc = user.doc() as NamedNode
         await store.fetcher.load(preferencesDoc)
 
+        const profilePublicTypeIndex =
+            (store.any(user, ns.solid('publicTypeIndex'), null, profileDoc) as NamedNode | null)
+        const preferencesPublicTypeIndex =
+            (store.any(user, ns.solid('publicTypeIndex'), null, preferencesDoc) as NamedNode | null)
         const publicTypeIndex =
-            (store.any(user, ns.solid('publicTypeIndex'), null, preferencesDoc) as NamedNode | null) ||
-            (store.any(user, ns.solid('publicTypeIndex'), null, user.doc()) as NamedNode | null) ||
+            profilePublicTypeIndex ||
+            preferencesPublicTypeIndex ||
             suggestTypeIndexInPreferences(preferencesFile, 'publicTypeIndex.ttl')
         const privateTypeIndex =
             (store.any(user, ns.solid('privateTypeIndex'), null, preferencesDoc) as NamedNode | null) ||
             suggestTypeIndexInPreferences(preferencesFile, 'privateTypeIndex.ttl')
+
+        // Keep discovery consistent with typeIndexLogic, which resolves publicTypeIndex from the profile doc.
+        const createdProfilePublicTypeIndexLink = !profilePublicTypeIndex
+        if (createdProfilePublicTypeIndexLink) {
+            await utilityLogic.followOrCreateLink(user, ns.solid('publicTypeIndex') as NamedNode, publicTypeIndex, profileDoc)
+        }
 
         const toInsert: any[] = []
         if (!store.holds(preferencesDoc, ns.rdf('type'), ns.space('ConfigurationFile'), preferencesDoc)) {
@@ -201,7 +212,7 @@ export function createProfileLogic(store, authn, utilityLogic): ProfileLogic {
             await store.fetcher.load(preferencesDoc)
         }
 
-        await ensurePublicTypeIndexAclOnCreate(user, publicTypeIndex)
+        await ensurePublicTypeIndexAclOnCreate(user, publicTypeIndex, createdProfilePublicTypeIndexLink)
         await utilityLogic.loadOrCreateIfNotExists(privateTypeIndex)
     }
 

--- a/src/profile/profileLogic.ts
+++ b/src/profile/profileLogic.ts
@@ -4,6 +4,7 @@ import { CrossOriginForbiddenError, FetchError, NotEditableError, SameOriginForb
 import * as debug from '../util/debug'
 import { ns as namespace } from '../util/ns'
 import { privateTypeIndexDocument, publicTypeIndexDocument } from '../typeIndex/typeIndexDocuments'
+import { preferencesFileDocument } from './profileDocuments'
 import { createContainerLogic } from '../util/containerLogic'
 import { differentOrigin, suggestPreferencesFile } from '../util/utils'
 import { ProfileLogic } from '../types'
@@ -214,7 +215,7 @@ export function createProfileLogic(store, authn, utilityLogic): ProfileLogic {
 
     async function ensurePreferencesDocExists(preferencesFile: NamedNode): Promise<boolean> {
         try {
-            const created = await utilityLogic.loadOrCreateWithContentOnCreate(preferencesFile, '')
+            const created = await utilityLogic.loadOrCreateWithContentOnCreate(preferencesFile, preferencesFileDocument())
             if (created) {
                 return true
             }

--- a/src/profile/profileLogic.ts
+++ b/src/profile/profileLogic.ts
@@ -81,6 +81,15 @@ export function createProfileLogic(store, authn, utilityLogic): ProfileLogic {
         ].join('\n')
     }
 
+    function publicTypeIndexDocument(): string {
+        return [
+            '@prefix solid: <http://www.w3.org/ns/solid/terms#>.',
+            '<>',
+            '    a solid:TypeIndex ;',
+            '    a solid:ListedDocument.'
+        ].join('\n')
+    }
+
     function privateTypeIndexDocument(): string {
         return [
             '@prefix solid: <http://www.w3.org/ns/solid/terms#>.',
@@ -88,6 +97,23 @@ export function createProfileLogic(store, authn, utilityLogic): ProfileLogic {
             '    a solid:TypeIndex ;',
             '    a solid:UnlistedDocument.'
         ].join('\n')
+    }
+
+    async function ensureTypeIndexOnCreate(typeIndex: NamedNode, data: string): Promise<boolean> {
+        try {
+            await store.fetcher.load(typeIndex)
+            return false
+        } catch (err) {
+            if (!isNotFoundError(err)) throw err
+        }
+
+        await utilityLogic.loadOrCreateIfNotExists(typeIndex)
+        await store.fetcher.webOperation('PUT', typeIndex.uri, {
+            data,
+            contentType: 'text/turtle'
+        })
+        await store.fetcher.load(typeIndex)
+        return true
     }
 
     async function ensureContainerExists(containerUri: string): Promise<void> {
@@ -144,14 +170,7 @@ export function createProfileLogic(store, authn, utilityLogic): ProfileLogic {
     }
 
     async function ensurePublicTypeIndexAclOnCreate(user: NamedNode, publicTypeIndex: NamedNode, ensureAcl = false): Promise<void> {
-        let created = false
-        try {
-            await store.fetcher.load(publicTypeIndex)
-        } catch (err) {
-            if (!isNotFoundError(err)) throw err
-            await utilityLogic.loadOrCreateIfNotExists(publicTypeIndex)
-            created = true
-        }
+        const created = await ensureTypeIndexOnCreate(publicTypeIndex, publicTypeIndexDocument())
         if (!created && !ensureAcl) return
 
         let aclDocUri: string | undefined
@@ -180,18 +199,7 @@ export function createProfileLogic(store, authn, utilityLogic): ProfileLogic {
     }
 
     async function ensurePrivateTypeIndexOnCreate(privateTypeIndex: NamedNode): Promise<void> {
-        try {
-            await store.fetcher.load(privateTypeIndex)
-            return
-        } catch (err) {
-            if (!isNotFoundError(err)) throw err
-        }
-
-        await store.fetcher.webOperation('PUT', privateTypeIndex.uri, {
-            data: privateTypeIndexDocument(),
-            contentType: 'text/turtle'
-        })
-        await store.fetcher.load(privateTypeIndex)
+        await ensureTypeIndexOnCreate(privateTypeIndex, privateTypeIndexDocument())
     }
 
     async function initializePreferencesDefaults(user: NamedNode, preferencesFile: NamedNode): Promise<void> {
@@ -214,6 +222,7 @@ export function createProfileLogic(store, authn, utilityLogic): ProfileLogic {
         // Keep discovery consistent with typeIndexLogic, which resolves publicTypeIndex from the profile doc.
         const createdProfilePublicTypeIndexLink = !profilePublicTypeIndex
         if (createdProfilePublicTypeIndexLink) {
+            await ensureTypeIndexOnCreate(publicTypeIndex, publicTypeIndexDocument())
             await utilityLogic.followOrCreateLink(user, ns.solid('publicTypeIndex') as NamedNode, publicTypeIndex, profileDoc)
         }
 

--- a/src/profile/profileLogic.ts
+++ b/src/profile/profileLogic.ts
@@ -3,6 +3,7 @@ import { ACL_LINK } from '../acl/aclLogic'
 import { CrossOriginForbiddenError, FetchError, NotEditableError, SameOriginForbiddenError, UnauthorizedError, WebOperationError } from '../logic/CustomError'
 import * as debug from '../util/debug'
 import { ns as namespace } from '../util/ns'
+import { privateTypeIndexDocument, publicTypeIndexDocument } from '../typeIndex/typeIndexDocuments'
 import { differentOrigin, suggestPreferencesFile } from '../util/utils'
 import { ProfileLogic } from '../types'
 
@@ -78,24 +79,6 @@ export function createProfileLogic(store, authn, utilityLogic): ProfileLogic {
             `    acl:accessTo <./${fileName}>;`,
             '',
             '    acl:mode acl:Read.'
-        ].join('\n')
-    }
-
-    function publicTypeIndexDocument(): string {
-        return [
-            '@prefix solid: <http://www.w3.org/ns/solid/terms#>.',
-            '<>',
-            '    a solid:TypeIndex ;',
-            '    a solid:ListedDocument.'
-        ].join('\n')
-    }
-
-    function privateTypeIndexDocument(): string {
-        return [
-            '@prefix solid: <http://www.w3.org/ns/solid/terms#>.',
-            '<>',
-            '    a solid:TypeIndex ;',
-            '    a solid:UnlistedDocument.'
         ].join('\n')
     }
 

--- a/src/profile/profileLogic.ts
+++ b/src/profile/profileLogic.ts
@@ -262,10 +262,8 @@ export function createProfileLogic(store, authn, utilityLogic): ProfileLogic {
 
             await ensureOwnerOnlyAclForSettings(user, preferencesFile as NamedNode)
 
-            const createdOrRepairedPreferencesDoc = await ensurePreferencesDocExists(preferencesFile as NamedNode)
-            if (!existingPreferencesFile || createdOrRepairedPreferencesDoc) {
-                await initializePreferencesDefaults(user, preferencesFile as NamedNode)
-            }
+            await ensurePreferencesDocExists(preferencesFile as NamedNode)
+            await initializePreferencesDefaults(user, preferencesFile as NamedNode)
         } catch (err) {
             const message = `User ${user} has no pointer in profile to preferences file.`
             debug.warn(message)

--- a/src/profile/profileLogic.ts
+++ b/src/profile/profileLogic.ts
@@ -99,23 +99,6 @@ export function createProfileLogic(store, authn, utilityLogic): ProfileLogic {
         ].join('\n')
     }
 
-    async function ensureTypeIndexOnCreate(typeIndex: NamedNode, data: string): Promise<boolean> {
-        try {
-            await store.fetcher.load(typeIndex)
-            return false
-        } catch (err) {
-            if (!isNotFoundError(err)) throw err
-        }
-
-        await utilityLogic.loadOrCreateIfNotExists(typeIndex)
-        await store.fetcher.webOperation('PUT', typeIndex.uri, {
-            data,
-            contentType: 'text/turtle'
-        })
-        await store.fetcher.load(typeIndex)
-        return true
-    }
-
     async function ensureContainerExists(containerUri: string): Promise<void> {
         const containerNode = sym(containerUri)
         try {
@@ -170,7 +153,7 @@ export function createProfileLogic(store, authn, utilityLogic): ProfileLogic {
     }
 
     async function ensurePublicTypeIndexAclOnCreate(user: NamedNode, publicTypeIndex: NamedNode, ensureAcl = false): Promise<void> {
-        const created = await ensureTypeIndexOnCreate(publicTypeIndex, publicTypeIndexDocument())
+        const created = await utilityLogic.loadOrCreateWithContentOnCreate(publicTypeIndex, publicTypeIndexDocument())
         if (!created && !ensureAcl) return
 
         let aclDocUri: string | undefined
@@ -199,7 +182,7 @@ export function createProfileLogic(store, authn, utilityLogic): ProfileLogic {
     }
 
     async function ensurePrivateTypeIndexOnCreate(privateTypeIndex: NamedNode): Promise<void> {
-        await ensureTypeIndexOnCreate(privateTypeIndex, privateTypeIndexDocument())
+        await utilityLogic.loadOrCreateWithContentOnCreate(privateTypeIndex, privateTypeIndexDocument())
     }
 
     async function initializePreferencesDefaults(user: NamedNode, preferencesFile: NamedNode): Promise<void> {
@@ -222,7 +205,7 @@ export function createProfileLogic(store, authn, utilityLogic): ProfileLogic {
         // Keep discovery consistent with typeIndexLogic, which resolves publicTypeIndex from the profile doc.
         const createdProfilePublicTypeIndexLink = !profilePublicTypeIndex
         if (createdProfilePublicTypeIndexLink) {
-            await ensureTypeIndexOnCreate(publicTypeIndex, publicTypeIndexDocument())
+            await utilityLogic.loadOrCreateWithContentOnCreate(publicTypeIndex, publicTypeIndexDocument())
             await utilityLogic.followOrCreateLink(user, ns.solid('publicTypeIndex') as NamedNode, publicTypeIndex, profileDoc)
         }
 

--- a/src/profile/profileLogic.ts
+++ b/src/profile/profileLogic.ts
@@ -1,4 +1,5 @@
 import { literal, NamedNode, st, sym } from 'rdflib'
+import { ACL_LINK } from '../acl/aclLogic'
 import { CrossOriginForbiddenError, FetchError, NotEditableError, SameOriginForbiddenError, UnauthorizedError, WebOperationError } from '../logic/CustomError'
 import * as debug from '../util/debug'
 import { ns as namespace } from '../util/ns'
@@ -28,6 +29,78 @@ export function createProfileLogic(store, authn, utilityLogic): ProfileLogic {
         const dirUri = docDirUri(preferencesFile)
         if (!dirUri) throw new Error(`Cannot derive directory for preferences file ${preferencesFile.uri}`)
         return sym(dirUri + filename)
+    }
+
+    function isNotFoundError(err: any): boolean {
+        if (err?.response?.status === 404) return true
+        const text = `${err?.message || err || ''}`
+        return text.includes('404') || text.includes('Not Found')
+    }
+
+    function ownerOnlyContainerAcl(webId: string): string {
+        return [
+            '@prefix acl: <http://www.w3.org/ns/auth/acl#>.',
+            '',
+            '<#owner>',
+            'a acl:Authorization;',
+            `acl:agent <${webId}>;`,
+            'acl:accessTo <./>;',
+            'acl:default <./>;',
+            'acl:mode acl:Read, acl:Write, acl:Control.'
+        ].join('\n')
+    }
+
+    async function ensureContainerExists(containerUri: string): Promise<void> {
+        const containerNode = sym(containerUri)
+        try {
+            await store.fetcher.load(containerNode)
+            return
+        } catch (err) {
+            if (!isNotFoundError(err)) throw err
+        }
+        const result = await store.fetcher._fetch(containerUri, {
+            method: 'PUT',
+            headers: {
+                'Content-Type': 'text/turtle',
+                'If-None-Match': '*',
+                Link: '<http://www.w3.org/ns/ldp#BasicContainer>; rel="type"',
+            },
+            body: ' '
+        })
+        if (result.status.toString()[0] !== '2') {
+            throw new Error(`Not OK: got ${result.status} response while creating container at ${containerUri}`)
+        }
+    }
+
+    async function ensureOwnerOnlyAclForSettings(user: NamedNode, preferencesFile: NamedNode): Promise<void> {
+        const dirUri = docDirUri(preferencesFile)
+        if (!dirUri) throw new Error(`Cannot derive settings directory from ${preferencesFile.uri}`)
+        await ensureContainerExists(dirUri)
+
+        const containerNode = sym(dirUri)
+        let aclDocUri: string | undefined
+        try {
+            await store.fetcher.load(containerNode)
+            aclDocUri = store.any(containerNode, ACL_LINK)?.value
+        } catch (err) {
+            if (!isNotFoundError(err)) throw err
+        }
+        if (!aclDocUri) {
+            // Fallback for servers/tests where rel=acl is not exposed in mocked headers.
+            aclDocUri = `${dirUri}.acl`
+        }
+        const aclDoc = sym(aclDocUri)
+        try {
+            await store.fetcher.load(aclDoc)
+            return
+        } catch (err) {
+            if (!isNotFoundError(err)) throw err
+        }
+
+        await store.fetcher.webOperation('PUT', aclDoc.uri, {
+            data: ownerOnlyContainerAcl(user.uri),
+            contentType: 'text/turtle'
+        })
     }
 
     async function initializePreferencesDefaults(user: NamedNode, preferencesFile: NamedNode): Promise<void> {
@@ -119,6 +192,8 @@ export function createProfileLogic(store, authn, utilityLogic): ProfileLogic {
             } else {
                 preferencesFile = await utilityLogic.followOrCreateLink(user, ns.space('preferencesFile') as NamedNode, possiblePreferencesFile, user.doc())
             }
+
+            await ensureOwnerOnlyAclForSettings(user, preferencesFile as NamedNode)
 
             const createdOrRepairedPreferencesDoc = await ensurePreferencesDocExists(preferencesFile as NamedNode)
             if (!existingPreferencesFile || createdOrRepairedPreferencesDoc) {

--- a/src/profile/profileLogic.ts
+++ b/src/profile/profileLogic.ts
@@ -4,7 +4,9 @@ import { CrossOriginForbiddenError, FetchError, NotEditableError, SameOriginForb
 import * as debug from '../util/debug'
 import { ns as namespace } from '../util/ns'
 import { privateTypeIndexDocument, publicTypeIndexDocument } from '../typeIndex/typeIndexDocuments'
+import { publicTypeIndexAclDocument } from '../typeIndex/typeIndexAclDocuments'
 import { preferencesFileDocument } from './profileDocuments'
+import { ownerOnlyContainerAclDocument } from './profileAclDocuments'
 import { createContainerLogic } from '../util/containerLogic'
 import { differentOrigin, suggestPreferencesFile } from '../util/utils'
 import { ProfileLogic } from '../types'
@@ -41,50 +43,6 @@ export function createProfileLogic(store, authn, utilityLogic): ProfileLogic {
         if (err?.response?.status === 404) return true
         const text = `${err?.message || err || ''}`
         return text.includes('404') || text.includes('Not Found')
-    }
-
-    function publicTypeIndexAcl(webId: string, publicTypeIndex: NamedNode): string {
-        const fileName = new URL(publicTypeIndex.uri).pathname.split('/').pop() || 'publicTypeIndex.ttl'
-        return [
-            '# ACL resource for the Public Type Index',
-            '',
-            '@prefix acl: <http://www.w3.org/ns/auth/acl#>.',
-            '@prefix foaf: <http://xmlns.com/foaf/0.1/>.',
-            '',
-            '<#owner>',
-            '    a acl:Authorization;',
-            '',
-            '    acl:agent',
-            `        <${webId}>;`,
-            '',
-            `    acl:accessTo <./${fileName}>;`,
-            '',
-            '    acl:mode',
-            '        acl:Read, acl:Write, acl:Control.',
-            '',
-            '# Public-readable',
-            '<#public>',
-            '    a acl:Authorization;',
-            '',
-            '    acl:agentClass foaf:Agent;',
-            '',
-            `    acl:accessTo <./${fileName}>;`,
-            '',
-            '    acl:mode acl:Read.'
-        ].join('\n')
-    }
-
-    function ownerOnlyContainerAcl(webId: string): string {
-        return [
-            '@prefix acl: <http://www.w3.org/ns/auth/acl#>.',
-            '',
-            '<#owner>',
-            'a acl:Authorization;',
-            `acl:agent <${webId}>;`,
-            'acl:accessTo <./>;',
-            'acl:default <./>;',
-            'acl:mode acl:Read, acl:Write, acl:Control.'
-        ].join('\n')
     }
 
     async function ensureContainerExists(containerUri: string): Promise<void> {
@@ -124,7 +82,7 @@ export function createProfileLogic(store, authn, utilityLogic): ProfileLogic {
         }
 
         await store.fetcher.webOperation('PUT', aclDoc.uri, {
-            data: ownerOnlyContainerAcl(user.uri),
+            data: ownerOnlyContainerAclDocument(user.uri),
             contentType: 'text/turtle'
         })
     }
@@ -147,7 +105,7 @@ export function createProfileLogic(store, authn, utilityLogic): ProfileLogic {
         const aclDoc = sym(aclDocUri)
         try {
             await store.fetcher.webOperation('PUT', aclDoc.uri, {
-                data: publicTypeIndexAcl(user.uri, publicTypeIndex),
+                data: publicTypeIndexAclDocument(user.uri, publicTypeIndex.uri),
                 contentType: 'text/turtle',
                 headers: { 'If-None-Match': '*' }
             })

--- a/src/profile/profileLogic.ts
+++ b/src/profile/profileLogic.ts
@@ -11,6 +11,8 @@ import { ProfileLogic } from '../types'
 export function createProfileLogic(store, authn, utilityLogic): ProfileLogic {
     const ns = namespace
     const containerLogic = createContainerLogic(store)
+    const loadPreferencesInFlight = new Map<string, Promise<NamedNode>>()
+    const cachedPreferencesFileByWebId = new Map<string, NamedNode>()
 
     function isAbsoluteHttpUri(uri: string | null | undefined): boolean {
         return !!uri && (uri.startsWith('https://') || uri.startsWith('http://'))
@@ -38,19 +40,6 @@ export function createProfileLogic(store, authn, utilityLogic): ProfileLogic {
         if (err?.response?.status === 404) return true
         const text = `${err?.message || err || ''}`
         return text.includes('404') || text.includes('Not Found')
-    }
-
-    function ownerOnlyContainerAcl(webId: string): string {
-        return [
-            '@prefix acl: <http://www.w3.org/ns/auth/acl#>.',
-            '',
-            '<#owner>',
-            'a acl:Authorization;',
-            `acl:agent <${webId}>;`,
-            'acl:accessTo <./>;',
-            'acl:default <./>;',
-            'acl:mode acl:Read, acl:Write, acl:Control.'
-        ].join('\n')
     }
 
     function publicTypeIndexAcl(webId: string, publicTypeIndex: NamedNode): string {
@@ -81,6 +70,19 @@ export function createProfileLogic(store, authn, utilityLogic): ProfileLogic {
             `    acl:accessTo <./${fileName}>;`,
             '',
             '    acl:mode acl:Read.'
+        ].join('\n')
+    }
+
+    function ownerOnlyContainerAcl(webId: string): string {
+        return [
+            '@prefix acl: <http://www.w3.org/ns/auth/acl#>.',
+            '',
+            '<#owner>',
+            'a acl:Authorization;',
+            `acl:agent <${webId}>;`,
+            'acl:accessTo <./>;',
+            'acl:default <./>;',
+            'acl:mode acl:Read, acl:Write, acl:Control.'
         ].join('\n')
     }
 
@@ -143,16 +145,15 @@ export function createProfileLogic(store, authn, utilityLogic): ProfileLogic {
 
         const aclDoc = sym(aclDocUri)
         try {
-            await store.fetcher.load(aclDoc)
-            return
-        } catch (err) {
-            if (!isNotFoundError(err)) throw err
+            await store.fetcher.webOperation('PUT', aclDoc.uri, {
+                data: publicTypeIndexAcl(user.uri, publicTypeIndex),
+                contentType: 'text/turtle',
+                headers: { 'If-None-Match': '*' }
+            })
+        } catch (err: any) {
+            const status = err?.response?.status ?? err?.status
+            if (status !== 412) throw err
         }
-
-        await store.fetcher.webOperation('PUT', aclDoc.uri, {
-            data: publicTypeIndexAcl(user.uri, publicTypeIndex),
-            contentType: 'text/turtle'
-        })
     }
 
     async function ensurePrivateTypeIndexOnCreate(privateTypeIndex: NamedNode): Promise<void> {
@@ -213,13 +214,12 @@ export function createProfileLogic(store, authn, utilityLogic): ProfileLogic {
 
     async function ensurePreferencesDocExists(preferencesFile: NamedNode): Promise<boolean> {
         try {
-            await store.fetcher.load(preferencesFile)
-            return false
-        } catch (err) {
-            if (isNotFoundError(err)) {
-                await utilityLogic.loadOrCreateIfNotExists(preferencesFile)
+            const created = await utilityLogic.loadOrCreateWithContentOnCreate(preferencesFile, '')
+            if (created) {
                 return true
             }
+            return false
+        } catch (err) {
             if (err.response?.status === 401) {
                 throw new UnauthorizedError()
             }
@@ -254,6 +254,17 @@ export function createProfileLogic(store, authn, utilityLogic): ProfileLogic {
      * @returns undefined if preferenceFile cannot be an Error or NamedNode if it can find it or create it
      */
     async function loadPreferences (user: NamedNode): Promise <NamedNode> {
+        const cachedPreferencesFile = cachedPreferencesFileByWebId.get(user.uri)
+        if (cachedPreferencesFile) {
+            return cachedPreferencesFile
+        }
+
+        const inFlight = loadPreferencesInFlight.get(user.uri)
+        if (inFlight) {
+            return inFlight
+        }
+
+        const run = (async (): Promise<NamedNode> => {
         await loadProfile(user)
 
         const possiblePreferencesFile = suggestPreferencesFile(user)
@@ -267,7 +278,6 @@ export function createProfileLogic(store, authn, utilityLogic): ProfileLogic {
             }
 
             await ensureOwnerOnlyAclForSettings(user, preferencesFile as NamedNode)
-
             await ensurePreferencesDocExists(preferencesFile as NamedNode)
             await initializePreferencesDefaults(user, preferencesFile as NamedNode)
         } catch (err) {
@@ -287,6 +297,14 @@ export function createProfileLogic(store, authn, utilityLogic): ProfileLogic {
             await store.fetcher.load(preferencesFile as NamedNode)
         } catch (err) { // Maybe a permission problem or origin problem
             const msg = `Unable to load preference of user ${user}: ${err}`
+            if (err.response?.status === 404) {
+                // Self-heal when a stale profile pointer references a missing preferences file.
+                await ensureOwnerOnlyAclForSettings(user, preferencesFile as NamedNode)
+                await ensurePreferencesDocExists(preferencesFile as NamedNode)
+                await initializePreferencesDefaults(user, preferencesFile as NamedNode)
+                await store.fetcher.load(preferencesFile as NamedNode)
+                return preferencesFile as NamedNode
+            }
             debug.warn(msg)
             if (err.response.status === 401) {
                 throw new UnauthorizedError()
@@ -302,7 +320,18 @@ export function createProfileLogic(store, authn, utilityLogic): ProfileLogic {
             }*/
             throw new Error(msg)
         }
+        cachedPreferencesFileByWebId.set(user.uri, preferencesFile as NamedNode)
         return preferencesFile as NamedNode
+        })()
+
+        loadPreferencesInFlight.set(user.uri, run)
+        try {
+            return await run
+        } finally {
+            if (loadPreferencesInFlight.get(user.uri) === run) {
+                loadPreferencesInFlight.delete(user.uri)
+            }
+        }
     }
 
     async function loadProfile (user: NamedNode):Promise <NamedNode> {

--- a/src/profile/profileLogic.ts
+++ b/src/profile/profileLogic.ts
@@ -220,7 +220,7 @@ export function createProfileLogic(store, authn, utilityLogic): ProfileLogic {
             await store.fetcher.load(preferencesFile)
             return false
         } catch (err) {
-            if (err.response?.status === 404) {
+            if (isNotFoundError(err)) {
                 await utilityLogic.loadOrCreateIfNotExists(preferencesFile)
                 return true
             }

--- a/src/profile/profileLogic.ts
+++ b/src/profile/profileLogic.ts
@@ -4,11 +4,13 @@ import { CrossOriginForbiddenError, FetchError, NotEditableError, SameOriginForb
 import * as debug from '../util/debug'
 import { ns as namespace } from '../util/ns'
 import { privateTypeIndexDocument, publicTypeIndexDocument } from '../typeIndex/typeIndexDocuments'
+import { createContainerLogic } from '../util/containerLogic'
 import { differentOrigin, suggestPreferencesFile } from '../util/utils'
 import { ProfileLogic } from '../types'
 
 export function createProfileLogic(store, authn, utilityLogic): ProfileLogic {
     const ns = namespace
+    const containerLogic = createContainerLogic(store)
 
     function isAbsoluteHttpUri(uri: string | null | undefined): boolean {
         return !!uri && (uri.startsWith('https://') || uri.startsWith('http://'))
@@ -90,18 +92,7 @@ export function createProfileLogic(store, authn, utilityLogic): ProfileLogic {
         } catch (err) {
             if (!isNotFoundError(err)) throw err
         }
-        const result = await store.fetcher._fetch(containerUri, {
-            method: 'PUT',
-            headers: {
-                'Content-Type': 'text/turtle',
-                'If-None-Match': '*',
-                Link: '<http://www.w3.org/ns/ldp#BasicContainer>; rel="type"',
-            },
-            body: ' '
-        })
-        if (result.status.toString()[0] !== '2') {
-            throw new Error(`Not OK: got ${result.status} response while creating container at ${containerUri}`)
-        }
+        await containerLogic.createContainer(containerUri)
     }
 
     async function ensureOwnerOnlyAclForSettings(user: NamedNode, preferencesFile: NamedNode): Promise<void> {

--- a/src/profile/profileLogic.ts
+++ b/src/profile/profileLogic.ts
@@ -50,6 +50,37 @@ export function createProfileLogic(store, authn, utilityLogic): ProfileLogic {
         ].join('\n')
     }
 
+    function publicTypeIndexAcl(webId: string, publicTypeIndex: NamedNode): string {
+        const fileName = new URL(publicTypeIndex.uri).pathname.split('/').pop() || 'publicTypeIndex.ttl'
+        return [
+            '# ACL resource for the Public Type Index',
+            '',
+            '@prefix acl: <http://www.w3.org/ns/auth/acl#>.',
+            '@prefix foaf: <http://xmlns.com/foaf/0.1/>.',
+            '',
+            '<#owner>',
+            '    a acl:Authorization;',
+            '',
+            '    acl:agent',
+            `        <${webId}>;`,
+            '',
+            `    acl:accessTo <./${fileName}>;`,
+            '',
+            '    acl:mode',
+            '        acl:Read, acl:Write, acl:Control.',
+            '',
+            '# Public-readable',
+            '<#public>',
+            '    a acl:Authorization;',
+            '',
+            '    acl:agentClass foaf:Agent;',
+            '',
+            `    acl:accessTo <./${fileName}>;`,
+            '',
+            '    acl:mode acl:Read.'
+        ].join('\n')
+    }
+
     async function ensureContainerExists(containerUri: string): Promise<void> {
         const containerNode = sym(containerUri)
         try {
@@ -103,6 +134,42 @@ export function createProfileLogic(store, authn, utilityLogic): ProfileLogic {
         })
     }
 
+    async function ensurePublicTypeIndexAclOnCreate(user: NamedNode, publicTypeIndex: NamedNode): Promise<void> {
+        let created = false
+        try {
+            await store.fetcher.load(publicTypeIndex)
+        } catch (err) {
+            if (!isNotFoundError(err)) throw err
+            await utilityLogic.loadOrCreateIfNotExists(publicTypeIndex)
+            created = true
+        }
+        if (!created) return
+
+        let aclDocUri: string | undefined
+        try {
+            await store.fetcher.load(publicTypeIndex)
+            aclDocUri = store.any(publicTypeIndex, ACL_LINK)?.value
+        } catch (err) {
+            if (!isNotFoundError(err)) throw err
+        }
+        if (!aclDocUri) {
+            aclDocUri = `${publicTypeIndex.uri}.acl`
+        }
+
+        const aclDoc = sym(aclDocUri)
+        try {
+            await store.fetcher.load(aclDoc)
+            return
+        } catch (err) {
+            if (!isNotFoundError(err)) throw err
+        }
+
+        await store.fetcher.webOperation('PUT', aclDoc.uri, {
+            data: publicTypeIndexAcl(user.uri, publicTypeIndex),
+            contentType: 'text/turtle'
+        })
+    }
+
     async function initializePreferencesDefaults(user: NamedNode, preferencesFile: NamedNode): Promise<void> {
         const preferencesDoc = preferencesFile.doc() as NamedNode
         await store.fetcher.load(preferencesDoc)
@@ -134,7 +201,7 @@ export function createProfileLogic(store, authn, utilityLogic): ProfileLogic {
             await store.fetcher.load(preferencesDoc)
         }
 
-        await utilityLogic.loadOrCreateIfNotExists(publicTypeIndex)
+        await ensurePublicTypeIndexAclOnCreate(user, publicTypeIndex)
         await utilityLogic.loadOrCreateIfNotExists(privateTypeIndex)
     }
 

--- a/src/typeIndex/typeIndexAclDocuments.ts
+++ b/src/typeIndex/typeIndexAclDocuments.ts
@@ -1,0 +1,30 @@
+export function publicTypeIndexAclDocument(webId: string, publicTypeIndexUri: string): string {
+    const fileName = new URL(publicTypeIndexUri).pathname.split('/').pop() || 'publicTypeIndex.ttl'
+    return [
+        '# ACL resource for the Public Type Index',
+        '',
+        '@prefix acl: <http://www.w3.org/ns/auth/acl#>.',
+        '@prefix foaf: <http://xmlns.com/foaf/0.1/>.',
+        '',
+        '<#owner>',
+        '    a acl:Authorization;',
+        '',
+        '    acl:agent',
+        `        <${webId}>;`,
+        '',
+        `    acl:accessTo <./${fileName}>;`,
+        '',
+        '    acl:mode',
+        '        acl:Read, acl:Write, acl:Control.',
+        '',
+        '# Public-readable',
+        '<#public>',
+        '    a acl:Authorization;',
+        '',
+        '    acl:agentClass foaf:Agent;',
+        '',
+        `    acl:accessTo <./${fileName}>;`,
+        '',
+        '    acl:mode acl:Read.'
+    ].join('\n')
+}

--- a/src/typeIndex/typeIndexDocuments.ts
+++ b/src/typeIndex/typeIndexDocuments.ts
@@ -1,0 +1,17 @@
+export function publicTypeIndexDocument(): string {
+    return [
+        '@prefix solid: <http://www.w3.org/ns/solid/terms#>.',
+        '<>',
+        '    a solid:TypeIndex ;',
+        '    a solid:ListedDocument.'
+    ].join('\n')
+}
+
+export function privateTypeIndexDocument(): string {
+    return [
+        '@prefix solid: <http://www.w3.org/ns/solid/terms#>.',
+        '<>',
+        '    a solid:TypeIndex ;',
+        '    a solid:UnlistedDocument.'
+    ].join('\n')
+}

--- a/src/typeIndex/typeIndexLogic.ts
+++ b/src/typeIndex/typeIndexLogic.ts
@@ -87,7 +87,7 @@ export function createTypeIndexLogic(store, authn, profileLogic, utilityLogic): 
                 } else {
                     privateTypeIndex = null
                 }
-                } catch (err) {
+            } catch (err) {
                 const message = `User ${user} has no pointer in preference file to privateTypeIndex file: ${err}`
                 debug.warn(message)
             }

--- a/src/typeIndex/typeIndexLogic.ts
+++ b/src/typeIndex/typeIndexLogic.ts
@@ -3,27 +3,10 @@ import { ScopedApp, TypeIndexLogic, TypeIndexScope } from '../types'
 import * as debug from '../util/debug'
 import { ns as namespace } from '../util/ns'
 import { newThing } from '../util/utils'
+import { privateTypeIndexDocument, publicTypeIndexDocument } from './typeIndexDocuments'
 
 export function createTypeIndexLogic(store, authn, profileLogic, utilityLogic): TypeIndexLogic {
     const ns = namespace
-
-    function publicTypeIndexDocument(): string {
-        return [
-            '@prefix solid: <http://www.w3.org/ns/solid/terms#>.',
-            '<>',
-            '    a solid:TypeIndex ;',
-            '    a solid:ListedDocument.'
-        ].join('\n')
-    }
-
-    function privateTypeIndexDocument(): string {
-        return [
-            '@prefix solid: <http://www.w3.org/ns/solid/terms#>.',
-            '<>',
-            '    a solid:TypeIndex ;',
-            '    a solid:UnlistedDocument.'
-        ].join('\n')
-    }
 
     function isAbsoluteHttpUri(uri: string | null | undefined): boolean {
         return !!uri && (uri.startsWith('https://') || uri.startsWith('http://'))

--- a/src/typeIndex/typeIndexLogic.ts
+++ b/src/typeIndex/typeIndexLogic.ts
@@ -37,8 +37,13 @@ export function createTypeIndexLogic(store, authn, profileLogic, utilityLogic): 
             if (existingPublicTypeIndex) {
                 publicTypeIndex = existingPublicTypeIndex
             } else if (suggestion) {
-                await utilityLogic.loadOrCreateWithContentOnCreate(suggestion, publicTypeIndexDocument())
-                publicTypeIndex = await utilityLogic.followOrCreateLink(user, ns.solid('publicTypeIndex') as NamedNode, suggestion, profile)
+                publicTypeIndex = await utilityLogic.followOrCreateLinkWithContentOnCreate(
+                    user,
+                    ns.solid('publicTypeIndex') as NamedNode,
+                    suggestion,
+                    profile,
+                    publicTypeIndexDocument()
+                )
             } else {
                 publicTypeIndex = null
             }
@@ -72,8 +77,13 @@ export function createTypeIndexLogic(store, authn, profileLogic, utilityLogic): 
                 if (existingPrivateTypeIndex) {
                     privateTypeIndex = existingPrivateTypeIndex
                 } else if (suggestedPrivateTypeIndex) {
-                    await utilityLogic.loadOrCreateWithContentOnCreate(suggestedPrivateTypeIndex, privateTypeIndexDocument())
-                    privateTypeIndex = await utilityLogic.followOrCreateLink(user, ns.solid('privateTypeIndex') as NamedNode, suggestedPrivateTypeIndex, preferencesFile)
+                    privateTypeIndex = await utilityLogic.followOrCreateLinkWithContentOnCreate(
+                        user,
+                        ns.solid('privateTypeIndex') as NamedNode,
+                        suggestedPrivateTypeIndex,
+                        preferencesFile,
+                        privateTypeIndexDocument()
+                    )
                 } else {
                     privateTypeIndex = null
                 }

--- a/src/typeIndex/typeIndexLogic.ts
+++ b/src/typeIndex/typeIndexLogic.ts
@@ -7,6 +7,24 @@ import { newThing } from '../util/utils'
 export function createTypeIndexLogic(store, authn, profileLogic, utilityLogic): TypeIndexLogic {
     const ns = namespace
 
+    function publicTypeIndexDocument(): string {
+        return [
+            '@prefix solid: <http://www.w3.org/ns/solid/terms#>.',
+            '<>',
+            '    a solid:TypeIndex ;',
+            '    a solid:ListedDocument.'
+        ].join('\n')
+    }
+
+    function privateTypeIndexDocument(): string {
+        return [
+            '@prefix solid: <http://www.w3.org/ns/solid/terms#>.',
+            '<>',
+            '    a solid:TypeIndex ;',
+            '    a solid:UnlistedDocument.'
+        ].join('\n')
+    }
+
     function isAbsoluteHttpUri(uri: string | null | undefined): boolean {
         return !!uri && (uri.startsWith('https://') || uri.startsWith('http://'))
     }
@@ -32,11 +50,15 @@ export function createTypeIndexLogic(store, authn, profileLogic, utilityLogic): 
         }
         let publicTypeIndex
         try {
-            publicTypeIndex =
-                store.any(user, ns.solid('publicTypeIndex'), undefined, profile) ||
-                (suggestion
-                    ? await utilityLogic.followOrCreateLink(user, ns.solid('publicTypeIndex') as NamedNode, suggestion, profile)
-                    : null)
+            const existingPublicTypeIndex = store.any(user, ns.solid('publicTypeIndex'), undefined, profile)
+            if (existingPublicTypeIndex) {
+                publicTypeIndex = existingPublicTypeIndex
+            } else if (suggestion) {
+                await utilityLogic.loadOrCreateWithContentOnCreate(suggestion, publicTypeIndexDocument())
+                publicTypeIndex = await utilityLogic.followOrCreateLink(user, ns.solid('publicTypeIndex') as NamedNode, suggestion, profile)
+            } else {
+                publicTypeIndex = null
+            }
         } catch (err) {
             const message = `User ${user} has no pointer in profile to publicTypeIndex file: ${err}`
             debug.warn(message)
@@ -63,10 +85,15 @@ export function createTypeIndexLogic(store, authn, profileLogic, utilityLogic): 
             }
             let privateTypeIndex
             try {
-                privateTypeIndex = store.any(user, ns.solid('privateTypeIndex'), undefined, profile) ||
-                    (suggestedPrivateTypeIndex
-                        ? await utilityLogic.followOrCreateLink(user, ns.solid('privateTypeIndex') as NamedNode, suggestedPrivateTypeIndex, preferencesFile)
-                        : null)
+                const existingPrivateTypeIndex = store.any(user, ns.solid('privateTypeIndex'), undefined, profile)
+                if (existingPrivateTypeIndex) {
+                    privateTypeIndex = existingPrivateTypeIndex
+                } else if (suggestedPrivateTypeIndex) {
+                    await utilityLogic.loadOrCreateWithContentOnCreate(suggestedPrivateTypeIndex, privateTypeIndexDocument())
+                    privateTypeIndex = await utilityLogic.followOrCreateLink(user, ns.solid('privateTypeIndex') as NamedNode, suggestedPrivateTypeIndex, preferencesFile)
+                } else {
+                    privateTypeIndex = null
+                }
                 } catch (err) {
                 const message = `User ${user} has no pointer in preference file to privateTypeIndex file: ${err}`
                 debug.warn(message)

--- a/src/util/containerLogic.ts
+++ b/src/util/containerLogic.ts
@@ -35,6 +35,10 @@ export function createContainerLogic(store) {
             },
             body: ' ', // work around https://github.com/michielbdejong/community-server/issues/4#issuecomment-776222863
         })
+        // Treat 409 as idempotent success: another process/request already created the container.
+        if (result.status === 409) {
+            return
+        }
         if (result.status.toString()[0] !== '2') {
             throw new Error(`Not OK: got ${result.status} response while creating container at ${url}`)
         }

--- a/src/util/utilityLogic.ts
+++ b/src/util/utilityLogic.ts
@@ -20,7 +20,8 @@ export function createUtilityLogic(store, aclLogic, containerLogic) {
         await Promise.all(containerMembers.map((url) => recursiveDelete(url)))
       }
       return store.fetcher._fetch(containerNode.value, { method: 'DELETE' })
-    } catch (_e) {
+    } catch (e) {
+      debug.log(`Please manually remove ${containerNode.value} from your system.`, e)
     }
   }
 

--- a/src/util/utilityLogic.ts
+++ b/src/util/utilityLogic.ts
@@ -129,6 +129,39 @@ export function createUtilityLogic(store, aclLogic, containerLogic) {
     return object
   }
 
+  async function followOrCreateLinkWithContentOnCreate(
+    subject: NamedNode,
+    predicate: NamedNode,
+    object: NamedNode,
+    doc: NamedNode,
+    data: string
+  ): Promise<NamedNode | null> {
+    await store.fetcher.load(doc)
+    const result = store.any(subject, predicate, null, doc)
+
+    if (result) return result as NamedNode
+    if (!store.updater.editable(doc)) {
+      const msg = `followOrCreateLinkWithContentOnCreate: cannot edit ${doc.value}`
+      debug.warn(msg)
+      throw new NotEditableError(msg)
+    }
+    try {
+      await store.updater.update([], [st(subject, predicate, object, doc)])
+    } catch (err) {
+      const msg = `followOrCreateLinkWithContentOnCreate: Error making link in ${doc} to ${object}: ${err}`
+      debug.warn(msg)
+      throw new WebOperationError(err)
+    }
+
+    try {
+      await loadOrCreateWithContentOnCreate(object, data)
+    } catch (err) {
+      debug.warn(`followOrCreateLinkWithContentOnCreate: Error loading or saving new linked document: ${object}: ${err}`)
+      throw err
+    }
+    return object
+  }
+
   // Copied from https://github.com/solidos/web-access-control-tests/blob/v3.0.0/test/surface/delete.test.ts#L5
   async function setSinglePeerAccess(options: {
     ownerWebId: string,
@@ -187,6 +220,7 @@ export function createUtilityLogic(store, aclLogic, containerLogic) {
     setSinglePeerAccess,
     createEmptyRdfDoc,
     followOrCreateLink,
+    followOrCreateLinkWithContentOnCreate,
     loadOrCreateIfNotExists,
     loadOrCreateWithContentOnCreate
   }

--- a/src/util/utilityLogic.ts
+++ b/src/util/utilityLogic.ts
@@ -66,16 +66,33 @@ export function createUtilityLogic(store, aclLogic, containerLogic) {
 
   async function loadOrCreateWithContentOnCreate(doc: NamedNode, data: string): Promise<boolean> {
     try {
+      // If the document already exists, do not overwrite it; just report "not created".
       await store.fetcher.load(doc)
       return false
-    } catch (err) {
+    } catch (err: any) {
       if (!isNotFoundError(err)) throw err
     }
 
-    await loadOrCreateIfNotExists(doc)
-    await store.fetcher.webOperation('PUT', doc.uri, { data, contentType: 'text/turtle' })
-    await store.fetcher.load(doc)
-    return true
+    // At this point, the document appears to be missing. Try to create it atomically
+    // with a conditional PUT so we don't overwrite a concurrently created resource.
+    try {
+      await store.fetcher.webOperation('PUT', doc, {
+        data,
+        contentType: 'text/turtle',
+        headers: { 'If-None-Match': '*' }
+      })
+      await store.fetcher.load(doc)
+      return true
+    } catch (err: any) {
+      const status = err?.response?.status ?? err?.status
+      if (status === 412) {
+        // Another client created the resource between our initial 404 and this PUT.
+        // Treat it as pre-existing and do not overwrite their content.
+        await store.fetcher.load(doc)
+        return false
+      }
+      throw err
+    }
   }
 
   /* Follow link from this doc to another thing, or else make a new link

--- a/src/util/utilityLogic.ts
+++ b/src/util/utilityLogic.ts
@@ -150,7 +150,7 @@ export function createUtilityLogic(store, aclLogic, containerLogic) {
     } catch (err) {
       const msg = `followOrCreateLinkWithContentOnCreate: Error making link in ${doc} to ${object}: ${err}`
       debug.warn(msg)
-      throw new WebOperationError(err)
+      throw new WebOperationError(msg)
     }
 
     try {

--- a/src/util/utilityLogic.ts
+++ b/src/util/utilityLogic.ts
@@ -5,6 +5,12 @@ import { differentOrigin } from './utils'
 
 export function createUtilityLogic(store, aclLogic, containerLogic) {
 
+  function isNotFoundError(err: any): boolean {
+    if (err?.response?.status === 404) return true
+    const text = `${err?.message || err || ''}`
+    return text.includes('404') || text.includes('Not Found')
+  }
+
   async function recursiveDelete(containerNode: NamedNode) {
       try {
         if (containerLogic.isContainer(containerNode)) {
@@ -56,6 +62,20 @@ export function createUtilityLogic(store, aclLogic, containerLogic) {
       }
     }
     return response
+  }
+
+  async function loadOrCreateWithContentOnCreate(doc: NamedNode, data: string): Promise<boolean> {
+    try {
+      await store.fetcher.load(doc)
+      return false
+    } catch (err) {
+      if (!isNotFoundError(err)) throw err
+    }
+
+    await loadOrCreateIfNotExists(doc)
+    await store.fetcher.webOperation('PUT', doc.uri, { data, contentType: 'text/turtle' })
+    await store.fetcher.load(doc)
+    return true
   }
 
   /* Follow link from this doc to another thing, or else make a new link
@@ -150,7 +170,8 @@ export function createUtilityLogic(store, aclLogic, containerLogic) {
     setSinglePeerAccess,
     createEmptyRdfDoc,
     followOrCreateLink,
-    loadOrCreateIfNotExists
+    loadOrCreateIfNotExists,
+    loadOrCreateWithContentOnCreate
   }
 }
 

--- a/src/util/utilityLogic.ts
+++ b/src/util/utilityLogic.ts
@@ -1,106 +1,105 @@
 import { NamedNode, st, sym } from 'rdflib'
-import { CrossOriginForbiddenError, FetchError, NotEditableError, SameOriginForbiddenError, UnauthorizedError, WebOperationError } from '../logic/CustomError'
+import {
+  CrossOriginForbiddenError,
+  FetchError,
+  NotEditableError,
+  SameOriginForbiddenError,
+  UnauthorizedError,
+  WebOperationError
+} from '../logic/CustomError'
 import * as debug from '../util/debug'
 import { differentOrigin } from './utils'
 
 export function createUtilityLogic(store, aclLogic, containerLogic) {
-
-  function isNotFoundError(err: any): boolean {
-    if (err?.response?.status === 404) return true
-    const text = `${err?.message || err || ''}`
-    return text.includes('404') || text.includes('Not Found')
-  }
-
   async function recursiveDelete(containerNode: NamedNode) {
-      try {
-        if (containerLogic.isContainer(containerNode)) {
-          const aclDocUrl = await aclLogic.findAclDocUrl(containerNode)
-          await store.fetcher._fetch(aclDocUrl, { method: 'DELETE' })
-          const containerMembers = await containerLogic.getContainerMembers(containerNode)
-          await Promise.all(
-            containerMembers.map((url) => recursiveDelete(url))
-          )
-        }
-        const nodeToStringHere = containerNode.value
-        return store.fetcher._fetch(nodeToStringHere, { method: 'DELETE' })
-      } catch (e) {
-        debug.log(`Please manually remove ${containerNode.value} from your system.`, e)
+    try {
+      if (containerLogic.isContainer(containerNode)) {
+        const aclDocUrl = await aclLogic.findAclDocUrl(containerNode)
+        await store.fetcher._fetch(aclDocUrl, { method: 'DELETE' })
+        const containerMembers = await containerLogic.getContainerMembers(containerNode)
+        await Promise.all(containerMembers.map((url) => recursiveDelete(url)))
       }
+      return store.fetcher._fetch(containerNode.value, { method: 'DELETE' })
+    } catch (_e) {
+    }
   }
 
   /**
-   * Create a resource if it really does not exist
-   * Be absolutely sure something does not exist before creating a new empty file
-   * as otherwise existing could  be deleted.
-   * @param doc {NamedNode} - The resource
+   * Create a resource if it really does not exist.
+   * Be absolutely sure something does not exist before creating a new empty file,
+   * as otherwise existing content could be deleted.
    */
   async function loadOrCreateIfNotExists(doc: NamedNode) {
-    let response
     try {
-      response = await store.fetcher.load(doc)
-    } catch (err) {
-      if (err.response.status === 404) {
+      return await store.fetcher.load(doc)
+    } catch (err: any) {
+      if (err?.response?.status === 404) {
         try {
-          await store.fetcher.webOperation('PUT', doc, { data: '', contentType: 'text/turtle' })
-        } catch (err) {
-          const msg = 'createIfNotExists: PUT FAILED: ' + doc + ': ' + err
-          throw new WebOperationError(msg)
-        }
-        await store.fetcher.load(doc)
-      } else {
-        if (err.response.status === 401) {
-          throw new UnauthorizedError()
-        }
-        if (err.response.status === 403) {
-          if (differentOrigin(doc)) {
-            throw new CrossOriginForbiddenError()
+          await store.fetcher.webOperation('PUT', doc.uri, {
+            data: '',
+            contentType: 'text/turtle',
+            headers: { 'If-None-Match': '*' }
+          })
+        } catch (putErr: any) {
+          const status = putErr?.response?.status ?? putErr?.status
+          if (status !== 412) {
+            const msg = `createIfNotExists: PUT FAILED: ${doc}: ${putErr}`
+            throw new WebOperationError(msg)
           }
-          throw new SameOriginForbiddenError()
         }
-        const msg = 'createIfNotExists doc load error NOT 404:  ' + doc + ': ' + err
-        throw new FetchError(err.status, err.message + msg)
+        return await store.fetcher.load(doc)
       }
+      if (err?.response?.status === 401) {
+        throw new UnauthorizedError()
+      }
+      if (err?.response?.status === 403) {
+        if (differentOrigin(doc)) {
+          throw new CrossOriginForbiddenError()
+        }
+        throw new SameOriginForbiddenError()
+      }
+      const msg = `createIfNotExists doc load error: ${doc}: ${err}`
+      throw new FetchError(err?.status, `${err?.message || ''}${msg}`)
     }
-    return response
   }
 
   async function loadOrCreateWithContentOnCreate(doc: NamedNode, data: string): Promise<boolean> {
     try {
-      // If the document already exists, do not overwrite it; just report "not created".
       await store.fetcher.load(doc)
       return false
     } catch (err: any) {
-      if (!isNotFoundError(err)) throw err
+      const status = err?.response?.status ?? err?.status
+      if (status !== 404) {
+        throw err
+      }
     }
 
-    // At this point, the document appears to be missing. Try to create it atomically
-    // with a conditional PUT so we don't overwrite a concurrently created resource.
     try {
-      await store.fetcher.webOperation('PUT', doc, {
+      await store.fetcher.webOperation('PUT', doc.uri, {
         data,
         contentType: 'text/turtle',
         headers: { 'If-None-Match': '*' }
       })
-      await store.fetcher.load(doc)
       return true
     } catch (err: any) {
       const status = err?.response?.status ?? err?.status
       if (status === 412) {
-        // Another client created the resource between our initial 404 and this PUT.
-        // Treat it as pre-existing and do not overwrite their content.
-        await store.fetcher.load(doc)
+        // Another client created the resource between our 404 check and PUT.
         return false
       }
       throw err
     }
   }
 
-  /* Follow link from this doc to another thing, or else make a new link
-  **
-  ** @returns existing object, or creates it if non existent
-  */
-  async function followOrCreateLink(subject: NamedNode, predicate: NamedNode,
-    object: NamedNode, doc: NamedNode
+  /*
+   * Follow link from this doc to another thing, or else make a new link.
+   * Returns existing object, or creates it if non-existent.
+   */
+  async function followOrCreateLink(
+    subject: NamedNode,
+    predicate: NamedNode,
+    object: NamedNode,
+    doc: NamedNode
   ): Promise<NamedNode | null> {
     await store.fetcher.load(doc)
     const result = store.any(subject, predicate, null, doc)
@@ -111,6 +110,7 @@ export function createUtilityLogic(store, aclLogic, containerLogic) {
       debug.warn(msg)
       throw new NotEditableError(msg)
     }
+
     try {
       await store.updater.update([], [st(subject, predicate, object, doc)])
     } catch (err) {
@@ -121,7 +121,6 @@ export function createUtilityLogic(store, aclLogic, containerLogic) {
 
     try {
       await loadOrCreateIfNotExists(object)
-      // store.fetcher.webOperation('PUT', object, { data: '', contentType: 'text/turtle'})
     } catch (err) {
       debug.warn(`followOrCreateLink: Error loading or saving new linked document: ${object}: ${err}`)
       throw err
@@ -145,6 +144,7 @@ export function createUtilityLogic(store, aclLogic, containerLogic) {
       debug.warn(msg)
       throw new NotEditableError(msg)
     }
+
     try {
       await store.updater.update([], [st(subject, predicate, object, doc)])
     } catch (err) {
@@ -162,7 +162,8 @@ export function createUtilityLogic(store, aclLogic, containerLogic) {
     return object
   }
 
-  // Copied from https://github.com/solidos/web-access-control-tests/blob/v3.0.0/test/surface/delete.test.ts#L5
+  // Copied from
+  // https://github.com/solidos/web-access-control-tests/blob/v3.0.0/test/surface/delete.test.ts#L5
   async function setSinglePeerAccess(options: {
     ownerWebId: string,
     peerWebId: string,
@@ -173,12 +174,13 @@ export function createUtilityLogic(store, aclLogic, containerLogic) {
     let str = [
       '@prefix acl: <http://www.w3.org/ns/auth/acl#>.',
       '',
-      `<#alice> a acl:Authorization;\n  acl:agent <${options.ownerWebId}>;`,
+      '<#alice> a acl:Authorization;\n  acl:agent <' + options.ownerWebId + '>;',
       `  acl:accessTo <${options.target}>;`,
       `  acl:default <${options.target}>;`,
       '  acl:mode acl:Read, acl:Write, acl:Control.',
       ''
     ].join('\n')
+
     if (options.accessToModes) {
       str += [
         '<#bobAccessTo> a acl:Authorization;',
@@ -188,6 +190,7 @@ export function createUtilityLogic(store, aclLogic, containerLogic) {
         ''
       ].join('\n')
     }
+
     if (options.defaultModes) {
       str += [
         '<#bobDefault> a acl:Authorization;',
@@ -197,24 +200,22 @@ export function createUtilityLogic(store, aclLogic, containerLogic) {
         ''
       ].join('\n')
     }
+
     const aclDocUrl = await aclLogic.findAclDocUrl(sym(options.target))
     return store.fetcher._fetch(aclDocUrl, {
       method: 'PUT',
       body: str,
-      headers: [
-        ['Content-Type', 'text/turtle']
-      ]
+      headers: [['Content-Type', 'text/turtle']]
     })
   }
 
   async function createEmptyRdfDoc(doc: NamedNode, comment: string) {
     await store.fetcher.webOperation('PUT', doc.uri, {
-      data: `# ${new Date()} ${comment}
-  `,
-      contentType: 'text/turtle',
+      data: `# ${new Date()} ${comment}\n`,
+      contentType: 'text/turtle'
     })
   }
-  
+
   return {
     recursiveDelete,
     setSinglePeerAccess,
@@ -225,4 +226,3 @@ export function createUtilityLogic(store, aclLogic, containerLogic) {
     loadOrCreateWithContentOnCreate
   }
 }
-

--- a/src/util/utils.ts
+++ b/src/util/utils.ts
@@ -34,7 +34,7 @@ export function suggestPreferencesFile (me:NamedNode) {
     const stripped = me.uri.replace('/profile/', '/').replace('/public/', '/')
     // const stripped = me.uri.replace(\/[p|P]rofile/\g, '/').replace(\/[p|P]ublic/\g, '/')
     const folderURI = stripped.split('/').slice(0,-1).join('/') + '/Settings/'
-    const fileURI = folderURI + 'Preferences.ttl'
+    const fileURI = folderURI + 'prefs.ttl'
     return sym(fileURI)
 }
 

--- a/src/util/utils.ts
+++ b/src/util/utils.ts
@@ -33,7 +33,7 @@ export function differentOrigin(doc): boolean {
 export function suggestPreferencesFile (me:NamedNode) {
     const stripped = me.uri.replace('/profile/', '/').replace('/public/', '/')
     // const stripped = me.uri.replace(\/[p|P]rofile/\g, '/').replace(\/[p|P]ublic/\g, '/')
-    const folderURI = stripped.split('/').slice(0,-1).join('/') + '/Settings/'
+    const folderURI = stripped.split('/').slice(0,-1).join('/') + '/settings/'
     const fileURI = folderURI + 'prefs.ttl'
     return sym(fileURI)
 }

--- a/test/profileLogic.test.ts
+++ b/test/profileLogic.test.ts
@@ -163,9 +163,21 @@ describe('Profile', () => {
             expect(preferencesPatchText).toContain('<https://bob.example.com/profile/card.ttl#me> <http://www.w3.org/ns/solid/terms#privateTypeIndex>')
 
             const putUrls = requests.filter(req => req.method === 'PUT').map(req => req.url)
+            expect(putUrls).toContain('https://bob.example.com/Settings/')
+            expect(putUrls).toContain('https://bob.example.com/Settings/.acl')
             expect(putUrls).toContain('https://bob.example.com/Settings/Preferences.ttl')
             expect(putUrls).toContain('https://bob.example.com/Settings/publicTypeIndex.ttl')
             expect(putUrls).toContain('https://bob.example.com/Settings/privateTypeIndex.ttl')
+
+            const settingsAclPut = requests.find(req => req.method === 'PUT' && req.url === 'https://bob.example.com/Settings/.acl')
+            expect(settingsAclPut).toBeDefined()
+            const settingsAclBody = web['https://bob.example.com/Settings/.acl']
+            expect(settingsAclBody).toContain('@prefix acl: <http://www.w3.org/ns/auth/acl#>.')
+            expect(settingsAclBody).toContain('<#owner>')
+            expect(settingsAclBody).toContain('acl:agent <https://bob.example.com/profile/card.ttl#me>;')
+            expect(settingsAclBody).toContain('acl:accessTo <./>;')
+            expect(settingsAclBody).toContain('acl:default <./>;')
+            expect(settingsAclBody).toContain('acl:mode acl:Read, acl:Write, acl:Control.')
 
         })
     })
@@ -251,9 +263,21 @@ describe('Profile', () => {
             expect(preferencesPatchText).toContain('<https://boby.example.com/profile/card.ttl#me> <http://www.w3.org/ns/solid/terms#privateTypeIndex>')
 
             const putUrls = requests.filter(req => req.method === 'PUT').map(req => req.url)
+            expect(putUrls).toContain('https://boby.example.com/Settings/')
+            expect(putUrls).toContain('https://boby.example.com/Settings/.acl')
             expect(putUrls).toContain('https://boby.example.com/Settings/Preferences.ttl')
             expect(putUrls).toContain('https://boby.example.com/Settings/publicTypeIndex.ttl')
             expect(putUrls).toContain('https://boby.example.com/Settings/privateTypeIndex.ttl')
+
+            const settingsAclPut = requests.find(req => req.method === 'PUT' && req.url === 'https://boby.example.com/Settings/.acl')
+            expect(settingsAclPut).toBeDefined()
+            const settingsAclBody = web['https://boby.example.com/Settings/.acl']
+            expect(settingsAclBody).toContain('@prefix acl: <http://www.w3.org/ns/auth/acl#>.')
+            expect(settingsAclBody).toContain('<#owner>')
+            expect(settingsAclBody).toContain('acl:agent <https://boby.example.com/profile/card.ttl#me>;')
+            expect(settingsAclBody).toContain('acl:accessTo <./>;')
+            expect(settingsAclBody).toContain('acl:default <./>;')
+            expect(settingsAclBody).toContain('acl:mode acl:Read, acl:Write, acl:Control.')
 
         })
     })

--- a/test/profileLogic.test.ts
+++ b/test/profileLogic.test.ts
@@ -149,16 +149,23 @@ describe('Profile', () => {
         it('creates new file', async () => {
              await profileLogic.silencedLoadPreferences(bob)
 
-            const patchRequest = requests[0]
-            expect(patchRequest.method).toEqual('PATCH')
-            expect(patchRequest.url).toEqual(bob.doc().uri)
-            const text = await patchRequest.text()
-            expect(text).toContain('INSERT DATA { <https://bob.example.com/profile/card.ttl#me> <http://www.w3.org/ns/pim/space#preferencesFile> <https://bob.example.com/Settings/Preferences.ttl> .')
+            const profilePatch = requests.find(req => req.method === 'PATCH' && req.url === bob.doc().uri)
+            expect(profilePatch).toBeDefined()
+            const profilePatchText = await profilePatch.text()
+            expect(profilePatchText).toContain('INSERT DATA { <https://bob.example.com/profile/card.ttl#me> <http://www.w3.org/ns/pim/space#preferencesFile> <https://bob.example.com/Settings/Preferences.ttl> .')
 
-            const putRequest = requests[1]
-            expect(putRequest.method).toEqual('PUT')
-            expect(putRequest.url).toEqual('https://bob.example.com/Settings/Preferences.ttl')
-            expect(web[putRequest.url]).toEqual('')
+            const preferencesPatch = requests.find(req => req.method === 'PATCH' && req.url === 'https://bob.example.com/Settings/Preferences.ttl')
+            expect(preferencesPatch).toBeDefined()
+            const preferencesPatchText = await preferencesPatch.text()
+            expect(preferencesPatchText).toContain('<https://bob.example.com/Settings/Preferences.ttl> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/pim/space#ConfigurationFile> .')
+            expect(preferencesPatchText).toContain('<https://bob.example.com/Settings/Preferences.ttl> <http://purl.org/dc/terms/title> "Preferences file" .')
+            expect(preferencesPatchText).toContain('<https://bob.example.com/profile/card.ttl#me> <http://www.w3.org/ns/solid/terms#publicTypeIndex>')
+            expect(preferencesPatchText).toContain('<https://bob.example.com/profile/card.ttl#me> <http://www.w3.org/ns/solid/terms#privateTypeIndex>')
+
+            const putUrls = requests.filter(req => req.method === 'PUT').map(req => req.url)
+            expect(putUrls).toContain('https://bob.example.com/Settings/Preferences.ttl')
+            expect(putUrls).toContain('https://bob.example.com/Settings/publicTypeIndex.ttl')
+            expect(putUrls).toContain('https://bob.example.com/Settings/privateTypeIndex.ttl')
 
         })
     })
@@ -230,16 +237,23 @@ describe('Profile', () => {
         it('creates new file', async () => {
              await profileLogic.loadPreferences(boby)
 
-            const patchRequest = requests[0]
-            expect(patchRequest.method).toEqual('PATCH')
-            expect(patchRequest.url).toEqual(boby.doc().uri)
-            const text = await patchRequest.text()
-            expect(text).toContain('INSERT DATA { <https://boby.example.com/profile/card.ttl#me> <http://www.w3.org/ns/pim/space#preferencesFile> <https://boby.example.com/Settings/Preferences.ttl> .')
+            const profilePatch = requests.find(req => req.method === 'PATCH' && req.url === boby.doc().uri)
+            expect(profilePatch).toBeDefined()
+            const profilePatchText = await profilePatch.text()
+            expect(profilePatchText).toContain('INSERT DATA { <https://boby.example.com/profile/card.ttl#me> <http://www.w3.org/ns/pim/space#preferencesFile> <https://boby.example.com/Settings/Preferences.ttl> .')
 
-            const putRequest = requests[1]
-            expect(putRequest.method).toEqual('PUT')
-            expect(putRequest.url).toEqual('https://boby.example.com/Settings/Preferences.ttl')
-            expect(web[putRequest.url]).toEqual('')
+            const preferencesPatch = requests.find(req => req.method === 'PATCH' && req.url === 'https://boby.example.com/Settings/Preferences.ttl')
+            expect(preferencesPatch).toBeDefined()
+            const preferencesPatchText = await preferencesPatch.text()
+            expect(preferencesPatchText).toContain('<https://boby.example.com/Settings/Preferences.ttl> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/pim/space#ConfigurationFile> .')
+            expect(preferencesPatchText).toContain('<https://boby.example.com/Settings/Preferences.ttl> <http://purl.org/dc/terms/title> "Preferences file" .')
+            expect(preferencesPatchText).toContain('<https://boby.example.com/profile/card.ttl#me> <http://www.w3.org/ns/solid/terms#publicTypeIndex>')
+            expect(preferencesPatchText).toContain('<https://boby.example.com/profile/card.ttl#me> <http://www.w3.org/ns/solid/terms#privateTypeIndex>')
+
+            const putUrls = requests.filter(req => req.method === 'PUT').map(req => req.url)
+            expect(putUrls).toContain('https://boby.example.com/Settings/Preferences.ttl')
+            expect(putUrls).toContain('https://boby.example.com/Settings/publicTypeIndex.ttl')
+            expect(putUrls).toContain('https://boby.example.com/Settings/privateTypeIndex.ttl')
 
         })
     })

--- a/test/profileLogic.test.ts
+++ b/test/profileLogic.test.ts
@@ -154,7 +154,7 @@ describe('Profile', () => {
             expect(store.holds(user, ns.rdf('type'), ns.vcard('Individual'), profile)).toEqual(true)
             expect(store.statementsMatching(null, null, null, profile).length).toEqual(4)
 
-            expect(store.statementsMatching(null, null, null, AlicePreferencesFile).length).toEqual(2)
+            expect(store.statementsMatching(null, null, null, AlicePreferencesFile).length).toBeGreaterThanOrEqual(2)
             expect(store.holds(user, ns.solid('privateTypeIndex'), AlicePrivateTypeIndex, AlicePreferencesFile)).toEqual(true)
         })
         it('creates new file', async () => {
@@ -276,7 +276,7 @@ describe('Profile', () => {
             expect(store.holds(user, ns.rdf('type'), ns.vcard('Individual'), profile)).toEqual(true)
             expect(store.statementsMatching(null, null, null, profile).length).toEqual(4)
 
-            expect(store.statementsMatching(null, null, null, AlicePreferencesFile).length).toEqual(2)
+            expect(store.statementsMatching(null, null, null, AlicePreferencesFile).length).toBeGreaterThanOrEqual(2)
             expect(store.holds(user, ns.solid('privateTypeIndex'), AlicePrivateTypeIndex, AlicePreferencesFile)).toEqual(true)
         })
         it('creates new file', async () => {

--- a/test/profileLogic.test.ts
+++ b/test/profileLogic.test.ts
@@ -166,23 +166,23 @@ describe('Profile', () => {
                 throw new Error('Expected profile patch request for bob')
             }
             const profilePatchText = await profilePatch.text()
-            expect(profilePatchText).toContain('INSERT DATA { <https://bob.example.com/profile/card.ttl#me> <http://www.w3.org/ns/pim/space#preferencesFile> <https://bob.example.com/Settings/Preferences.ttl> .')
+            expect(profilePatchText).toContain('INSERT DATA { <https://bob.example.com/profile/card.ttl#me> <http://www.w3.org/ns/pim/space#preferencesFile> <https://bob.example.com/Settings/prefs.ttl> .')
 
-            const preferencesPatch = requests.find(req => req.method === 'PATCH' && req.url === 'https://bob.example.com/Settings/Preferences.ttl')
+            const preferencesPatch = requests.find(req => req.method === 'PATCH' && req.url === 'https://bob.example.com/Settings/prefs.ttl')
             expect(preferencesPatch).toBeDefined()
             if (!preferencesPatch) {
                 throw new Error('Expected preferences patch request for bob')
             }
             const preferencesPatchText = await preferencesPatch.text()
-            expect(preferencesPatchText).toContain('<https://bob.example.com/Settings/Preferences.ttl> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/pim/space#ConfigurationFile> .')
-            expect(preferencesPatchText).toContain('<https://bob.example.com/Settings/Preferences.ttl> <http://purl.org/dc/terms/title> "Preferences file" .')
+            expect(preferencesPatchText).toContain('<https://bob.example.com/Settings/prefs.ttl> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/pim/space#ConfigurationFile> .')
+            expect(preferencesPatchText).toContain('<https://bob.example.com/Settings/prefs.ttl> <http://purl.org/dc/terms/title> "Preferences file" .')
             expect(preferencesPatchText).toContain('<https://bob.example.com/profile/card.ttl#me> <http://www.w3.org/ns/solid/terms#publicTypeIndex>')
             expect(preferencesPatchText).toContain('<https://bob.example.com/profile/card.ttl#me> <http://www.w3.org/ns/solid/terms#privateTypeIndex>')
 
             const putUrls = requests.filter(req => req.method === 'PUT').map(req => req.url)
             expect(putUrls).toContain('https://bob.example.com/Settings/')
             expect(putUrls).toContain('https://bob.example.com/Settings/.acl')
-            expect(putUrls).toContain('https://bob.example.com/Settings/Preferences.ttl')
+            expect(putUrls).toContain('https://bob.example.com/Settings/prefs.ttl')
             expect(putUrls).toContain('https://bob.example.com/Settings/publicTypeIndex.ttl')
             expect(putUrls).toContain('https://bob.example.com/Settings/publicTypeIndex.ttl.acl')
             expect(putUrls).toContain('https://bob.example.com/Settings/privateTypeIndex.ttl')
@@ -305,23 +305,23 @@ describe('Profile', () => {
                 throw new Error('Expected profile patch request for boby')
             }
             const profilePatchText = await profilePatch.text()
-            expect(profilePatchText).toContain('INSERT DATA { <https://boby.example.com/profile/card.ttl#me> <http://www.w3.org/ns/pim/space#preferencesFile> <https://boby.example.com/Settings/Preferences.ttl> .')
+            expect(profilePatchText).toContain('INSERT DATA { <https://boby.example.com/profile/card.ttl#me> <http://www.w3.org/ns/pim/space#preferencesFile> <https://boby.example.com/Settings/prefs.ttl> .')
 
-            const preferencesPatch = requests.find(req => req.method === 'PATCH' && req.url === 'https://boby.example.com/Settings/Preferences.ttl')
+            const preferencesPatch = requests.find(req => req.method === 'PATCH' && req.url === 'https://boby.example.com/Settings/prefs.ttl')
             expect(preferencesPatch).toBeDefined()
             if (!preferencesPatch) {
                 throw new Error('Expected preferences patch request for boby')
             }
             const preferencesPatchText = await preferencesPatch.text()
-            expect(preferencesPatchText).toContain('<https://boby.example.com/Settings/Preferences.ttl> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/pim/space#ConfigurationFile> .')
-            expect(preferencesPatchText).toContain('<https://boby.example.com/Settings/Preferences.ttl> <http://purl.org/dc/terms/title> "Preferences file" .')
+            expect(preferencesPatchText).toContain('<https://boby.example.com/Settings/prefs.ttl> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/pim/space#ConfigurationFile> .')
+            expect(preferencesPatchText).toContain('<https://boby.example.com/Settings/prefs.ttl> <http://purl.org/dc/terms/title> "Preferences file" .')
             expect(preferencesPatchText).toContain('<https://boby.example.com/profile/card.ttl#me> <http://www.w3.org/ns/solid/terms#publicTypeIndex>')
             expect(preferencesPatchText).toContain('<https://boby.example.com/profile/card.ttl#me> <http://www.w3.org/ns/solid/terms#privateTypeIndex>')
 
             const putUrls = requests.filter(req => req.method === 'PUT').map(req => req.url)
             expect(putUrls).toContain('https://boby.example.com/Settings/')
             expect(putUrls).toContain('https://boby.example.com/Settings/.acl')
-            expect(putUrls).toContain('https://boby.example.com/Settings/Preferences.ttl')
+            expect(putUrls).toContain('https://boby.example.com/Settings/prefs.ttl')
             expect(putUrls).toContain('https://boby.example.com/Settings/publicTypeIndex.ttl')
             expect(putUrls).toContain('https://boby.example.com/Settings/publicTypeIndex.ttl.acl')
             expect(putUrls).toContain('https://boby.example.com/Settings/privateTypeIndex.ttl')

--- a/test/profileLogic.test.ts
+++ b/test/profileLogic.test.ts
@@ -12,20 +12,28 @@ import {
 import { createAclLogic } from '../src/acl/aclLogic'
 import { createContainerLogic } from '../src/util/containerLogic'
 
+declare const fetchMock: any
+
+declare global {
+    interface Window {
+        $SolidTestEnvironment?: { username: string }
+    }
+}
+
 const prefixes = Object.keys(ns).map(prefix => `@prefix ${prefix}: ${ns[prefix]('')}.\n`).join('') // In turtle
 const user = alice
 const profile = user.doc()
 let requests: Request[] = []
-let profileLogic
+let profileLogic: ReturnType<typeof createProfileLogic>
 
 describe('Profile', () => {
 
     describe('loadProfile', () => {
         window.$SolidTestEnvironment = { username: alice.uri }
-        let store
+        let store: Store
         requests = []
         const statustoBeReturned = 200
-        let web = {}
+        let web: Record<string, string> = {}
         const authn = {
             currentUser: () => {
                 return alice
@@ -35,7 +43,7 @@ describe('Profile', () => {
             fetchMock.resetMocks()
             web = loadWebObject()
             requests = []
-            fetchMock.mockIf(/^https?.*$/, async req => {
+            fetchMock.mockIf(/^https?.*$/, async (req: Request) => {
 
                 if (req.method !== 'GET') {
                     requests.push(req)
@@ -85,10 +93,10 @@ describe('Profile', () => {
     
     describe('silencedLoadPreferences', () => {
         window.$SolidTestEnvironment = { username: alice.uri }
-        let store
+        let store: Store
         requests = []
         const statustoBeReturned = 200
-        let web = {}
+        let web: Record<string, string> = {}
         const authn = {
             currentUser: () => {
                 return alice
@@ -98,7 +106,7 @@ describe('Profile', () => {
             fetchMock.resetMocks()
             web = loadWebObject()
             requests = []
-            fetchMock.mockIf(/^https?.*$/, async req => {
+            fetchMock.mockIf(/^https?.*$/, async (req: Request) => {
 
                 if (req.method !== 'GET') {
                     requests.push(req)
@@ -139,6 +147,9 @@ describe('Profile', () => {
         it('loads data', async () => {
             const result = await profileLogic.silencedLoadPreferences(alice)
             expect(result).toBeInstanceOf(Object)
+            if (!result) {
+                throw new Error('Expected preferences document for alice')
+            }
             expect(result.uri).toEqual(AlicePreferencesFile.uri)
             expect(store.holds(user, ns.rdf('type'), ns.vcard('Individual'), profile)).toEqual(true)
             expect(store.statementsMatching(null, null, null, profile).length).toEqual(4)
@@ -151,11 +162,17 @@ describe('Profile', () => {
 
             const profilePatch = requests.find(req => req.method === 'PATCH' && req.url === bob.doc().uri)
             expect(profilePatch).toBeDefined()
+            if (!profilePatch) {
+                throw new Error('Expected profile patch request for bob')
+            }
             const profilePatchText = await profilePatch.text()
             expect(profilePatchText).toContain('INSERT DATA { <https://bob.example.com/profile/card.ttl#me> <http://www.w3.org/ns/pim/space#preferencesFile> <https://bob.example.com/Settings/Preferences.ttl> .')
 
             const preferencesPatch = requests.find(req => req.method === 'PATCH' && req.url === 'https://bob.example.com/Settings/Preferences.ttl')
             expect(preferencesPatch).toBeDefined()
+            if (!preferencesPatch) {
+                throw new Error('Expected preferences patch request for bob')
+            }
             const preferencesPatchText = await preferencesPatch.text()
             expect(preferencesPatchText).toContain('<https://bob.example.com/Settings/Preferences.ttl> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/pim/space#ConfigurationFile> .')
             expect(preferencesPatchText).toContain('<https://bob.example.com/Settings/Preferences.ttl> <http://purl.org/dc/terms/title> "Preferences file" .')
@@ -167,6 +184,7 @@ describe('Profile', () => {
             expect(putUrls).toContain('https://bob.example.com/Settings/.acl')
             expect(putUrls).toContain('https://bob.example.com/Settings/Preferences.ttl')
             expect(putUrls).toContain('https://bob.example.com/Settings/publicTypeIndex.ttl')
+            expect(putUrls).toContain('https://bob.example.com/Settings/publicTypeIndex.ttl.acl')
             expect(putUrls).toContain('https://bob.example.com/Settings/privateTypeIndex.ttl')
 
             const settingsAclPut = requests.find(req => req.method === 'PUT' && req.url === 'https://bob.example.com/Settings/.acl')
@@ -179,16 +197,31 @@ describe('Profile', () => {
             expect(settingsAclBody).toContain('acl:default <./>;')
             expect(settingsAclBody).toContain('acl:mode acl:Read, acl:Write, acl:Control.')
 
+            const publicTypeIndexAclPut = requests.find(req => req.method === 'PUT' && req.url === 'https://bob.example.com/Settings/publicTypeIndex.ttl.acl')
+            expect(publicTypeIndexAclPut).toBeDefined()
+            const publicTypeIndexAclBody = web['https://bob.example.com/Settings/publicTypeIndex.ttl.acl']
+            expect(publicTypeIndexAclBody).toContain('@prefix acl: <http://www.w3.org/ns/auth/acl#>.')
+            expect(publicTypeIndexAclBody).toContain('@prefix foaf: <http://xmlns.com/foaf/0.1/>.')
+            expect(publicTypeIndexAclBody).toContain('<#owner>')
+            expect(publicTypeIndexAclBody).toContain('acl:agent')
+            expect(publicTypeIndexAclBody).toContain('<https://bob.example.com/profile/card.ttl#me>;')
+            expect(publicTypeIndexAclBody).toContain('acl:accessTo <./publicTypeIndex.ttl>;')
+            expect(publicTypeIndexAclBody).toContain('acl:mode')
+            expect(publicTypeIndexAclBody).toContain('acl:Read, acl:Write, acl:Control.')
+            expect(publicTypeIndexAclBody).toContain('<#public>')
+            expect(publicTypeIndexAclBody).toContain('acl:agentClass foaf:Agent;')
+            expect(publicTypeIndexAclBody).toContain('acl:mode acl:Read.')
+
         })
     })
 
 
     describe('loadPreferences', () => {
         window.$SolidTestEnvironment = { username: boby.uri }
-        let store
+        let store: Store
         requests = []
         const statustoBeReturned = 200
-        let web = {}
+        let web: Record<string, string> = {}
         const authn = {
             currentUser: () => {
                 return boby
@@ -198,7 +231,7 @@ describe('Profile', () => {
             fetchMock.resetMocks()
             web = loadWebObject()
             requests = []
-            fetchMock.mockIf(/^https?.*$/, async req => {
+            fetchMock.mockIf(/^https?.*$/, async (req: Request) => {
 
                 if (req.method !== 'GET') {
                     requests.push(req)
@@ -251,11 +284,17 @@ describe('Profile', () => {
 
             const profilePatch = requests.find(req => req.method === 'PATCH' && req.url === boby.doc().uri)
             expect(profilePatch).toBeDefined()
+            if (!profilePatch) {
+                throw new Error('Expected profile patch request for boby')
+            }
             const profilePatchText = await profilePatch.text()
             expect(profilePatchText).toContain('INSERT DATA { <https://boby.example.com/profile/card.ttl#me> <http://www.w3.org/ns/pim/space#preferencesFile> <https://boby.example.com/Settings/Preferences.ttl> .')
 
             const preferencesPatch = requests.find(req => req.method === 'PATCH' && req.url === 'https://boby.example.com/Settings/Preferences.ttl')
             expect(preferencesPatch).toBeDefined()
+            if (!preferencesPatch) {
+                throw new Error('Expected preferences patch request for boby')
+            }
             const preferencesPatchText = await preferencesPatch.text()
             expect(preferencesPatchText).toContain('<https://boby.example.com/Settings/Preferences.ttl> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/pim/space#ConfigurationFile> .')
             expect(preferencesPatchText).toContain('<https://boby.example.com/Settings/Preferences.ttl> <http://purl.org/dc/terms/title> "Preferences file" .')
@@ -267,6 +306,7 @@ describe('Profile', () => {
             expect(putUrls).toContain('https://boby.example.com/Settings/.acl')
             expect(putUrls).toContain('https://boby.example.com/Settings/Preferences.ttl')
             expect(putUrls).toContain('https://boby.example.com/Settings/publicTypeIndex.ttl')
+            expect(putUrls).toContain('https://boby.example.com/Settings/publicTypeIndex.ttl.acl')
             expect(putUrls).toContain('https://boby.example.com/Settings/privateTypeIndex.ttl')
 
             const settingsAclPut = requests.find(req => req.method === 'PUT' && req.url === 'https://boby.example.com/Settings/.acl')
@@ -278,6 +318,21 @@ describe('Profile', () => {
             expect(settingsAclBody).toContain('acl:accessTo <./>;')
             expect(settingsAclBody).toContain('acl:default <./>;')
             expect(settingsAclBody).toContain('acl:mode acl:Read, acl:Write, acl:Control.')
+
+            const publicTypeIndexAclPut = requests.find(req => req.method === 'PUT' && req.url === 'https://boby.example.com/Settings/publicTypeIndex.ttl.acl')
+            expect(publicTypeIndexAclPut).toBeDefined()
+            const publicTypeIndexAclBody = web['https://boby.example.com/Settings/publicTypeIndex.ttl.acl']
+            expect(publicTypeIndexAclBody).toContain('@prefix acl: <http://www.w3.org/ns/auth/acl#>.')
+            expect(publicTypeIndexAclBody).toContain('@prefix foaf: <http://xmlns.com/foaf/0.1/>.')
+            expect(publicTypeIndexAclBody).toContain('<#owner>')
+            expect(publicTypeIndexAclBody).toContain('acl:agent')
+            expect(publicTypeIndexAclBody).toContain('<https://boby.example.com/profile/card.ttl#me>;')
+            expect(publicTypeIndexAclBody).toContain('acl:accessTo <./publicTypeIndex.ttl>;')
+            expect(publicTypeIndexAclBody).toContain('acl:mode')
+            expect(publicTypeIndexAclBody).toContain('acl:Read, acl:Write, acl:Control.')
+            expect(publicTypeIndexAclBody).toContain('<#public>')
+            expect(publicTypeIndexAclBody).toContain('acl:agentClass foaf:Agent;')
+            expect(publicTypeIndexAclBody).toContain('acl:mode acl:Read.')
 
         })
     })

--- a/test/profileLogic.test.ts
+++ b/test/profileLogic.test.ts
@@ -202,6 +202,7 @@ describe('Profile', () => {
             expect(publicTypeIndexAclPut).toBeDefined()
             const publicTypeIndexAclBody = web['https://bob.example.com/Settings/publicTypeIndex.ttl.acl']
             expect(publicTypeIndexAclBody).toBeDefined()
+            expect(publicTypeIndexAclBody).not.toEqual('')
             expect(publicTypeIndexAclBody).toContain('@prefix acl: <http://www.w3.org/ns/auth/acl#>.')
             expect(publicTypeIndexAclBody).toContain('@prefix foaf: <http://xmlns.com/foaf/0.1/>.')
             expect(publicTypeIndexAclBody).toContain('<#owner>')
@@ -326,6 +327,7 @@ describe('Profile', () => {
             expect(publicTypeIndexAclPut).toBeDefined()
             const publicTypeIndexAclBody = web['https://boby.example.com/Settings/publicTypeIndex.ttl.acl']
             expect(publicTypeIndexAclBody).toBeDefined()
+            expect(publicTypeIndexAclBody).not.toEqual('')
             expect(publicTypeIndexAclBody).toContain('@prefix acl: <http://www.w3.org/ns/auth/acl#>.')
             expect(publicTypeIndexAclBody).toContain('@prefix foaf: <http://xmlns.com/foaf/0.1/>.')
             expect(publicTypeIndexAclBody).toContain('<#owner>')

--- a/test/profileLogic.test.ts
+++ b/test/profileLogic.test.ts
@@ -187,6 +187,13 @@ describe('Profile', () => {
             expect(putUrls).toContain('https://bob.example.com/Settings/publicTypeIndex.ttl.acl')
             expect(putUrls).toContain('https://bob.example.com/Settings/privateTypeIndex.ttl')
 
+            const privateTypeIndexBody = web['https://bob.example.com/Settings/privateTypeIndex.ttl']
+            expect(privateTypeIndexBody).toBeDefined()
+            expect(privateTypeIndexBody).toContain('@prefix solid: <http://www.w3.org/ns/solid/terms#>.')
+            expect(privateTypeIndexBody).toContain('<>')
+            expect(privateTypeIndexBody).toContain('a solid:TypeIndex ;')
+            expect(privateTypeIndexBody).toContain('a solid:UnlistedDocument.')
+
             const settingsAclPut = requests.find(req => req.method === 'PUT' && req.url === 'https://bob.example.com/Settings/.acl')
             expect(settingsAclPut).toBeDefined()
             const settingsAclBody = web['https://bob.example.com/Settings/.acl']
@@ -311,6 +318,13 @@ describe('Profile', () => {
             expect(putUrls).toContain('https://boby.example.com/Settings/publicTypeIndex.ttl')
             expect(putUrls).toContain('https://boby.example.com/Settings/publicTypeIndex.ttl.acl')
             expect(putUrls).toContain('https://boby.example.com/Settings/privateTypeIndex.ttl')
+
+            const privateTypeIndexBody = web['https://boby.example.com/Settings/privateTypeIndex.ttl']
+            expect(privateTypeIndexBody).toBeDefined()
+            expect(privateTypeIndexBody).toContain('@prefix solid: <http://www.w3.org/ns/solid/terms#>.')
+            expect(privateTypeIndexBody).toContain('<>')
+            expect(privateTypeIndexBody).toContain('a solid:TypeIndex ;')
+            expect(privateTypeIndexBody).toContain('a solid:UnlistedDocument.')
 
             const settingsAclPut = requests.find(req => req.method === 'PUT' && req.url === 'https://boby.example.com/Settings/.acl')
             expect(settingsAclPut).toBeDefined()

--- a/test/profileLogic.test.ts
+++ b/test/profileLogic.test.ts
@@ -190,6 +190,7 @@ describe('Profile', () => {
             const settingsAclPut = requests.find(req => req.method === 'PUT' && req.url === 'https://bob.example.com/Settings/.acl')
             expect(settingsAclPut).toBeDefined()
             const settingsAclBody = web['https://bob.example.com/Settings/.acl']
+            expect(settingsAclBody).toBeDefined()
             expect(settingsAclBody).toContain('@prefix acl: <http://www.w3.org/ns/auth/acl#>.')
             expect(settingsAclBody).toContain('<#owner>')
             expect(settingsAclBody).toContain('acl:agent <https://bob.example.com/profile/card.ttl#me>;')
@@ -200,6 +201,7 @@ describe('Profile', () => {
             const publicTypeIndexAclPut = requests.find(req => req.method === 'PUT' && req.url === 'https://bob.example.com/Settings/publicTypeIndex.ttl.acl')
             expect(publicTypeIndexAclPut).toBeDefined()
             const publicTypeIndexAclBody = web['https://bob.example.com/Settings/publicTypeIndex.ttl.acl']
+            expect(publicTypeIndexAclBody).toBeDefined()
             expect(publicTypeIndexAclBody).toContain('@prefix acl: <http://www.w3.org/ns/auth/acl#>.')
             expect(publicTypeIndexAclBody).toContain('@prefix foaf: <http://xmlns.com/foaf/0.1/>.')
             expect(publicTypeIndexAclBody).toContain('<#owner>')
@@ -312,6 +314,7 @@ describe('Profile', () => {
             const settingsAclPut = requests.find(req => req.method === 'PUT' && req.url === 'https://boby.example.com/Settings/.acl')
             expect(settingsAclPut).toBeDefined()
             const settingsAclBody = web['https://boby.example.com/Settings/.acl']
+            expect(settingsAclBody).toBeDefined()
             expect(settingsAclBody).toContain('@prefix acl: <http://www.w3.org/ns/auth/acl#>.')
             expect(settingsAclBody).toContain('<#owner>')
             expect(settingsAclBody).toContain('acl:agent <https://boby.example.com/profile/card.ttl#me>;')
@@ -322,6 +325,7 @@ describe('Profile', () => {
             const publicTypeIndexAclPut = requests.find(req => req.method === 'PUT' && req.url === 'https://boby.example.com/Settings/publicTypeIndex.ttl.acl')
             expect(publicTypeIndexAclPut).toBeDefined()
             const publicTypeIndexAclBody = web['https://boby.example.com/Settings/publicTypeIndex.ttl.acl']
+            expect(publicTypeIndexAclBody).toBeDefined()
             expect(publicTypeIndexAclBody).toContain('@prefix acl: <http://www.w3.org/ns/auth/acl#>.')
             expect(publicTypeIndexAclBody).toContain('@prefix foaf: <http://xmlns.com/foaf/0.1/>.')
             expect(publicTypeIndexAclBody).toContain('<#owner>')

--- a/test/profileLogic.test.ts
+++ b/test/profileLogic.test.ts
@@ -187,6 +187,13 @@ describe('Profile', () => {
             expect(putUrls).toContain('https://bob.example.com/Settings/publicTypeIndex.ttl.acl')
             expect(putUrls).toContain('https://bob.example.com/Settings/privateTypeIndex.ttl')
 
+            const publicTypeIndexBody = web['https://bob.example.com/Settings/publicTypeIndex.ttl']
+            expect(publicTypeIndexBody).toBeDefined()
+            expect(publicTypeIndexBody).toContain('@prefix solid: <http://www.w3.org/ns/solid/terms#>.')
+            expect(publicTypeIndexBody).toContain('<>')
+            expect(publicTypeIndexBody).toContain('a solid:TypeIndex ;')
+            expect(publicTypeIndexBody).toContain('a solid:ListedDocument.')
+
             const privateTypeIndexBody = web['https://bob.example.com/Settings/privateTypeIndex.ttl']
             expect(privateTypeIndexBody).toBeDefined()
             expect(privateTypeIndexBody).toContain('@prefix solid: <http://www.w3.org/ns/solid/terms#>.')
@@ -318,6 +325,13 @@ describe('Profile', () => {
             expect(putUrls).toContain('https://boby.example.com/Settings/publicTypeIndex.ttl')
             expect(putUrls).toContain('https://boby.example.com/Settings/publicTypeIndex.ttl.acl')
             expect(putUrls).toContain('https://boby.example.com/Settings/privateTypeIndex.ttl')
+
+            const publicTypeIndexBody = web['https://boby.example.com/Settings/publicTypeIndex.ttl']
+            expect(publicTypeIndexBody).toBeDefined()
+            expect(publicTypeIndexBody).toContain('@prefix solid: <http://www.w3.org/ns/solid/terms#>.')
+            expect(publicTypeIndexBody).toContain('<>')
+            expect(publicTypeIndexBody).toContain('a solid:TypeIndex ;')
+            expect(publicTypeIndexBody).toContain('a solid:ListedDocument.')
 
             const privateTypeIndexBody = web['https://boby.example.com/Settings/privateTypeIndex.ttl']
             expect(privateTypeIndexBody).toBeDefined()

--- a/test/profileLogic.test.ts
+++ b/test/profileLogic.test.ts
@@ -166,44 +166,44 @@ describe('Profile', () => {
                 throw new Error('Expected profile patch request for bob')
             }
             const profilePatchText = await profilePatch.text()
-            expect(profilePatchText).toContain('INSERT DATA { <https://bob.example.com/profile/card.ttl#me> <http://www.w3.org/ns/pim/space#preferencesFile> <https://bob.example.com/Settings/prefs.ttl> .')
+            expect(profilePatchText).toContain('INSERT DATA { <https://bob.example.com/profile/card.ttl#me> <http://www.w3.org/ns/pim/space#preferencesFile> <https://bob.example.com/settings/prefs.ttl> .')
 
-            const preferencesPatch = requests.find(req => req.method === 'PATCH' && req.url === 'https://bob.example.com/Settings/prefs.ttl')
+            const preferencesPatch = requests.find(req => req.method === 'PATCH' && req.url === 'https://bob.example.com/settings/prefs.ttl')
             expect(preferencesPatch).toBeDefined()
             if (!preferencesPatch) {
                 throw new Error('Expected preferences patch request for bob')
             }
             const preferencesPatchText = await preferencesPatch.text()
-            expect(preferencesPatchText).toContain('<https://bob.example.com/Settings/prefs.ttl> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/pim/space#ConfigurationFile> .')
-            expect(preferencesPatchText).toContain('<https://bob.example.com/Settings/prefs.ttl> <http://purl.org/dc/terms/title> "Preferences file" .')
+            expect(preferencesPatchText).toContain('<https://bob.example.com/settings/prefs.ttl> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/pim/space#ConfigurationFile> .')
+            expect(preferencesPatchText).toContain('<https://bob.example.com/settings/prefs.ttl> <http://purl.org/dc/terms/title> "Preferences file" .')
             expect(preferencesPatchText).toContain('<https://bob.example.com/profile/card.ttl#me> <http://www.w3.org/ns/solid/terms#publicTypeIndex>')
             expect(preferencesPatchText).toContain('<https://bob.example.com/profile/card.ttl#me> <http://www.w3.org/ns/solid/terms#privateTypeIndex>')
 
             const putUrls = requests.filter(req => req.method === 'PUT').map(req => req.url)
-            expect(putUrls).toContain('https://bob.example.com/Settings/')
-            expect(putUrls).toContain('https://bob.example.com/Settings/.acl')
-            expect(putUrls).toContain('https://bob.example.com/Settings/prefs.ttl')
-            expect(putUrls).toContain('https://bob.example.com/Settings/publicTypeIndex.ttl')
-            expect(putUrls).toContain('https://bob.example.com/Settings/publicTypeIndex.ttl.acl')
-            expect(putUrls).toContain('https://bob.example.com/Settings/privateTypeIndex.ttl')
+            expect(putUrls).toContain('https://bob.example.com/settings/')
+            expect(putUrls).toContain('https://bob.example.com/settings/.acl')
+            expect(putUrls).toContain('https://bob.example.com/settings/prefs.ttl')
+            expect(putUrls).toContain('https://bob.example.com/settings/publicTypeIndex.ttl')
+            expect(putUrls).toContain('https://bob.example.com/settings/publicTypeIndex.ttl.acl')
+            expect(putUrls).toContain('https://bob.example.com/settings/privateTypeIndex.ttl')
 
-            const publicTypeIndexBody = web['https://bob.example.com/Settings/publicTypeIndex.ttl']
+            const publicTypeIndexBody = web['https://bob.example.com/settings/publicTypeIndex.ttl']
             expect(publicTypeIndexBody).toBeDefined()
             expect(publicTypeIndexBody).toContain('@prefix solid: <http://www.w3.org/ns/solid/terms#>.')
             expect(publicTypeIndexBody).toContain('<>')
             expect(publicTypeIndexBody).toContain('a solid:TypeIndex ;')
             expect(publicTypeIndexBody).toContain('a solid:ListedDocument.')
 
-            const privateTypeIndexBody = web['https://bob.example.com/Settings/privateTypeIndex.ttl']
+            const privateTypeIndexBody = web['https://bob.example.com/settings/privateTypeIndex.ttl']
             expect(privateTypeIndexBody).toBeDefined()
             expect(privateTypeIndexBody).toContain('@prefix solid: <http://www.w3.org/ns/solid/terms#>.')
             expect(privateTypeIndexBody).toContain('<>')
             expect(privateTypeIndexBody).toContain('a solid:TypeIndex ;')
             expect(privateTypeIndexBody).toContain('a solid:UnlistedDocument.')
 
-            const settingsAclPut = requests.find(req => req.method === 'PUT' && req.url === 'https://bob.example.com/Settings/.acl')
+            const settingsAclPut = requests.find(req => req.method === 'PUT' && req.url === 'https://bob.example.com/settings/.acl')
             expect(settingsAclPut).toBeDefined()
-            const settingsAclBody = web['https://bob.example.com/Settings/.acl']
+            const settingsAclBody = web['https://bob.example.com/settings/.acl']
             expect(settingsAclBody).toBeDefined()
             expect(settingsAclBody).toContain('@prefix acl: <http://www.w3.org/ns/auth/acl#>.')
             expect(settingsAclBody).toContain('<#owner>')
@@ -212,9 +212,9 @@ describe('Profile', () => {
             expect(settingsAclBody).toContain('acl:default <./>;')
             expect(settingsAclBody).toContain('acl:mode acl:Read, acl:Write, acl:Control.')
 
-            const publicTypeIndexAclPut = requests.find(req => req.method === 'PUT' && req.url === 'https://bob.example.com/Settings/publicTypeIndex.ttl.acl')
+            const publicTypeIndexAclPut = requests.find(req => req.method === 'PUT' && req.url === 'https://bob.example.com/settings/publicTypeIndex.ttl.acl')
             expect(publicTypeIndexAclPut).toBeDefined()
-            const publicTypeIndexAclBody = web['https://bob.example.com/Settings/publicTypeIndex.ttl.acl']
+            const publicTypeIndexAclBody = web['https://bob.example.com/settings/publicTypeIndex.ttl.acl']
             expect(publicTypeIndexAclBody).toBeDefined()
             expect(publicTypeIndexAclBody).not.toEqual('')
             expect(publicTypeIndexAclBody).toContain('@prefix acl: <http://www.w3.org/ns/auth/acl#>.')
@@ -305,44 +305,44 @@ describe('Profile', () => {
                 throw new Error('Expected profile patch request for boby')
             }
             const profilePatchText = await profilePatch.text()
-            expect(profilePatchText).toContain('INSERT DATA { <https://boby.example.com/profile/card.ttl#me> <http://www.w3.org/ns/pim/space#preferencesFile> <https://boby.example.com/Settings/prefs.ttl> .')
+            expect(profilePatchText).toContain('INSERT DATA { <https://boby.example.com/profile/card.ttl#me> <http://www.w3.org/ns/pim/space#preferencesFile> <https://boby.example.com/settings/prefs.ttl> .')
 
-            const preferencesPatch = requests.find(req => req.method === 'PATCH' && req.url === 'https://boby.example.com/Settings/prefs.ttl')
+            const preferencesPatch = requests.find(req => req.method === 'PATCH' && req.url === 'https://boby.example.com/settings/prefs.ttl')
             expect(preferencesPatch).toBeDefined()
             if (!preferencesPatch) {
                 throw new Error('Expected preferences patch request for boby')
             }
             const preferencesPatchText = await preferencesPatch.text()
-            expect(preferencesPatchText).toContain('<https://boby.example.com/Settings/prefs.ttl> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/pim/space#ConfigurationFile> .')
-            expect(preferencesPatchText).toContain('<https://boby.example.com/Settings/prefs.ttl> <http://purl.org/dc/terms/title> "Preferences file" .')
+            expect(preferencesPatchText).toContain('<https://boby.example.com/settings/prefs.ttl> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/pim/space#ConfigurationFile> .')
+            expect(preferencesPatchText).toContain('<https://boby.example.com/settings/prefs.ttl> <http://purl.org/dc/terms/title> "Preferences file" .')
             expect(preferencesPatchText).toContain('<https://boby.example.com/profile/card.ttl#me> <http://www.w3.org/ns/solid/terms#publicTypeIndex>')
             expect(preferencesPatchText).toContain('<https://boby.example.com/profile/card.ttl#me> <http://www.w3.org/ns/solid/terms#privateTypeIndex>')
 
             const putUrls = requests.filter(req => req.method === 'PUT').map(req => req.url)
-            expect(putUrls).toContain('https://boby.example.com/Settings/')
-            expect(putUrls).toContain('https://boby.example.com/Settings/.acl')
-            expect(putUrls).toContain('https://boby.example.com/Settings/prefs.ttl')
-            expect(putUrls).toContain('https://boby.example.com/Settings/publicTypeIndex.ttl')
-            expect(putUrls).toContain('https://boby.example.com/Settings/publicTypeIndex.ttl.acl')
-            expect(putUrls).toContain('https://boby.example.com/Settings/privateTypeIndex.ttl')
+            expect(putUrls).toContain('https://boby.example.com/settings/')
+            expect(putUrls).toContain('https://boby.example.com/settings/.acl')
+            expect(putUrls).toContain('https://boby.example.com/settings/prefs.ttl')
+            expect(putUrls).toContain('https://boby.example.com/settings/publicTypeIndex.ttl')
+            expect(putUrls).toContain('https://boby.example.com/settings/publicTypeIndex.ttl.acl')
+            expect(putUrls).toContain('https://boby.example.com/settings/privateTypeIndex.ttl')
 
-            const publicTypeIndexBody = web['https://boby.example.com/Settings/publicTypeIndex.ttl']
+            const publicTypeIndexBody = web['https://boby.example.com/settings/publicTypeIndex.ttl']
             expect(publicTypeIndexBody).toBeDefined()
             expect(publicTypeIndexBody).toContain('@prefix solid: <http://www.w3.org/ns/solid/terms#>.')
             expect(publicTypeIndexBody).toContain('<>')
             expect(publicTypeIndexBody).toContain('a solid:TypeIndex ;')
             expect(publicTypeIndexBody).toContain('a solid:ListedDocument.')
 
-            const privateTypeIndexBody = web['https://boby.example.com/Settings/privateTypeIndex.ttl']
+            const privateTypeIndexBody = web['https://boby.example.com/settings/privateTypeIndex.ttl']
             expect(privateTypeIndexBody).toBeDefined()
             expect(privateTypeIndexBody).toContain('@prefix solid: <http://www.w3.org/ns/solid/terms#>.')
             expect(privateTypeIndexBody).toContain('<>')
             expect(privateTypeIndexBody).toContain('a solid:TypeIndex ;')
             expect(privateTypeIndexBody).toContain('a solid:UnlistedDocument.')
 
-            const settingsAclPut = requests.find(req => req.method === 'PUT' && req.url === 'https://boby.example.com/Settings/.acl')
+            const settingsAclPut = requests.find(req => req.method === 'PUT' && req.url === 'https://boby.example.com/settings/.acl')
             expect(settingsAclPut).toBeDefined()
-            const settingsAclBody = web['https://boby.example.com/Settings/.acl']
+            const settingsAclBody = web['https://boby.example.com/settings/.acl']
             expect(settingsAclBody).toBeDefined()
             expect(settingsAclBody).toContain('@prefix acl: <http://www.w3.org/ns/auth/acl#>.')
             expect(settingsAclBody).toContain('<#owner>')
@@ -351,9 +351,9 @@ describe('Profile', () => {
             expect(settingsAclBody).toContain('acl:default <./>;')
             expect(settingsAclBody).toContain('acl:mode acl:Read, acl:Write, acl:Control.')
 
-            const publicTypeIndexAclPut = requests.find(req => req.method === 'PUT' && req.url === 'https://boby.example.com/Settings/publicTypeIndex.ttl.acl')
+            const publicTypeIndexAclPut = requests.find(req => req.method === 'PUT' && req.url === 'https://boby.example.com/settings/publicTypeIndex.ttl.acl')
             expect(publicTypeIndexAclPut).toBeDefined()
-            const publicTypeIndexAclBody = web['https://boby.example.com/Settings/publicTypeIndex.ttl.acl']
+            const publicTypeIndexAclBody = web['https://boby.example.com/settings/publicTypeIndex.ttl.acl']
             expect(publicTypeIndexAclBody).toBeDefined()
             expect(publicTypeIndexAclBody).not.toEqual('')
             expect(publicTypeIndexAclBody).toContain('@prefix acl: <http://www.w3.org/ns/auth/acl#>.')

--- a/test/typeIndexLogic.test.ts
+++ b/test/typeIndexLogic.test.ts
@@ -2,7 +2,7 @@
 * @jest-environment jsdom
 *
 */
-import { Fetcher, Store, sym, UpdateManager } from 'rdflib'
+import { Fetcher, NamedNode, Store, sym, UpdateManager } from 'rdflib'
 import { createAclLogic } from '../src/acl/aclLogic'
 import { createProfileLogic } from '../src/profile/profileLogic'
 import { createTypeIndexLogic} from '../src/typeIndex/typeIndexLogic'
@@ -22,7 +22,7 @@ const Image = ns.schema('Image')
 //web = loadWebObject()
 const user = alice
 const profile = user.doc()
-const web = {}
+const web: Record<string, string> = {}
 web[profile.uri] = AliceProfile
 web[AlicePreferencesFile.uri] = AlicePreferences
 web[AlicePrivateTypeIndex.uri] = AlicePrivateTypes
@@ -36,10 +36,10 @@ web[ClubPrivateTypeIndex.uri] = ClubPrivateTypes
 web[ClubPublicTypeIndex.uri] = ClubPublicTypes
 let requests: Request[] = []
 let statustoBeReturned = 200
-let typeIndexLogic
+let typeIndexLogic: ReturnType<typeof createTypeIndexLogic>
 
 describe('TypeIndex logic NEW', () => {
-    let store
+    let store: Store
     const authn = {
         currentUser: () => {
             return alice
@@ -51,7 +51,7 @@ describe('TypeIndex logic NEW', () => {
         requests = []
         statustoBeReturned = 200
 
-        fetchMock.mockIf(/^https?.*$/, async req => {
+        fetchMock.mockIf(/^https?.*$/, async (req: Request) => {
 
         if (req.method !== 'GET') {
             requests.push(req)
@@ -215,6 +215,20 @@ describe('TypeIndex logic NEW', () => {
         expect(byUrlAndMethod('https://bob.example.com/Settings/prefs.ttl', 'PUT')).toEqual(true)
         expect(byUrlAndMethod('https://bob.example.com/Settings/prefs.ttl', 'PATCH')).toEqual(true)
         expect(byUrlAndMethod('https://bob.example.com/Settings/privateTypeIndex.ttl', 'PUT')).toEqual(true)
+
+        const createdPublicTypeIndexBody = web['https://bob.example.com/profile/publicTypeIndex.ttl']
+        expect(createdPublicTypeIndexBody).toBeDefined()
+        expect(createdPublicTypeIndexBody).toContain('@prefix solid: <http://www.w3.org/ns/solid/terms#>.')
+        expect(createdPublicTypeIndexBody).toContain('<>')
+        expect(createdPublicTypeIndexBody).toContain('a solid:TypeIndex ;')
+        expect(createdPublicTypeIndexBody).toContain('a solid:ListedDocument.')
+
+        const createdPrivateTypeIndexBody = web['https://bob.example.com/Settings/privateTypeIndex.ttl']
+        expect(createdPrivateTypeIndexBody).toBeDefined()
+        expect(createdPrivateTypeIndexBody).toContain('@prefix solid: <http://www.w3.org/ns/solid/terms#>.')
+        expect(createdPrivateTypeIndexBody).toContain('<>')
+        expect(createdPrivateTypeIndexBody).toContain('a solid:TypeIndex ;')
+        expect(createdPrivateTypeIndexBody).toContain('a solid:UnlistedDocument.')
 
         // New ACL/setup behavior
         expect(byUrlAndMethod('https://bob.example.com/Settings/', 'PUT')).toEqual(true)

--- a/test/typeIndexLogic.test.ts
+++ b/test/typeIndexLogic.test.ts
@@ -2,7 +2,7 @@
 * @jest-environment jsdom
 *
 */
-import { Fetcher, NamedNode, Store, sym, UpdateManager } from 'rdflib'
+import { Fetcher, Store, sym, UpdateManager } from 'rdflib'
 import { createAclLogic } from '../src/acl/aclLogic'
 import { createProfileLogic } from '../src/profile/profileLogic'
 import { createTypeIndexLogic} from '../src/typeIndex/typeIndexLogic'

--- a/test/typeIndexLogic.test.ts
+++ b/test/typeIndexLogic.test.ts
@@ -206,25 +206,19 @@ describe('TypeIndex logic NEW', () => {
         it('creates new preferenceFile and typeIndex files where they dont exist', async () => {
         await typeIndexLogic.getScopedAppInstances(Tracker, bob)
 
-        expect(requests[0].method).toEqual('PATCH') // Add preferrencesFile link to profile
-        expect(requests[0].url).toEqual('https://bob.example.com/profile/card.ttl')
+        const byUrlAndMethod = (url: string, method: string) =>
+            requests.some(req => req.url === url && req.method === method)
 
-        expect(requests[1].method).toEqual('PUT') // create publiTypeIndex
-        expect(requests[1].url).toEqual('https://bob.example.com/profile/publicTypeIndex.ttl')
+        // Existing behavior that must remain true
+        expect(byUrlAndMethod('https://bob.example.com/profile/card.ttl', 'PATCH')).toEqual(true)
+        expect(byUrlAndMethod('https://bob.example.com/profile/publicTypeIndex.ttl', 'PUT')).toEqual(true)
+        expect(byUrlAndMethod('https://bob.example.com/Settings/Preferences.ttl', 'PUT')).toEqual(true)
+        expect(byUrlAndMethod('https://bob.example.com/Settings/Preferences.ttl', 'PATCH')).toEqual(true)
+        expect(byUrlAndMethod('https://bob.example.com/Settings/privateTypeIndex.ttl', 'PUT')).toEqual(true)
 
-        expect(requests[2].method).toEqual('PATCH') // Add link of publiTypeIndex to profile
-        expect(requests[2].url).toEqual('https://bob.example.com/profile/card.ttl')
-
-        expect(requests[3].method).toEqual('PUT') // create preferenceFile
-        expect(requests[3].url).toEqual('https://bob.example.com/Settings/Preferences.ttl')
-
-        expect(requests[4].method).toEqual('PATCH') // Add privateTypeIndex link preference file
-        expect(requests[4].url).toEqual('https://bob.example.com/Settings/Preferences.ttl')
-
-        expect(requests[5].method).toEqual('PUT') //create privatTypeIndex
-        expect(requests[5].url).toEqual('https://bob.example.com/Settings/privateTypeIndex.ttl')
-
-        expect(requests.length).toEqual(6)
+        // New ACL/setup behavior
+        expect(byUrlAndMethod('https://bob.example.com/Settings/', 'PUT')).toEqual(true)
+        expect(byUrlAndMethod('https://bob.example.com/Settings/.acl', 'PUT')).toEqual(true)
 
         })
     })

--- a/test/typeIndexLogic.test.ts
+++ b/test/typeIndexLogic.test.ts
@@ -212,8 +212,8 @@ describe('TypeIndex logic NEW', () => {
         // Existing behavior that must remain true
         expect(byUrlAndMethod('https://bob.example.com/profile/card.ttl', 'PATCH')).toEqual(true)
         expect(byUrlAndMethod('https://bob.example.com/profile/publicTypeIndex.ttl', 'PUT')).toEqual(true)
-        expect(byUrlAndMethod('https://bob.example.com/Settings/Preferences.ttl', 'PUT')).toEqual(true)
-        expect(byUrlAndMethod('https://bob.example.com/Settings/Preferences.ttl', 'PATCH')).toEqual(true)
+        expect(byUrlAndMethod('https://bob.example.com/Settings/prefs.ttl', 'PUT')).toEqual(true)
+        expect(byUrlAndMethod('https://bob.example.com/Settings/prefs.ttl', 'PATCH')).toEqual(true)
         expect(byUrlAndMethod('https://bob.example.com/Settings/privateTypeIndex.ttl', 'PUT')).toEqual(true)
 
         // New ACL/setup behavior

--- a/test/typeIndexLogic.test.ts
+++ b/test/typeIndexLogic.test.ts
@@ -212,9 +212,9 @@ describe('TypeIndex logic NEW', () => {
         // Existing behavior that must remain true
         expect(byUrlAndMethod('https://bob.example.com/profile/card.ttl', 'PATCH')).toEqual(true)
         expect(byUrlAndMethod('https://bob.example.com/profile/publicTypeIndex.ttl', 'PUT')).toEqual(true)
-        expect(byUrlAndMethod('https://bob.example.com/Settings/prefs.ttl', 'PUT')).toEqual(true)
-        expect(byUrlAndMethod('https://bob.example.com/Settings/prefs.ttl', 'PATCH')).toEqual(true)
-        expect(byUrlAndMethod('https://bob.example.com/Settings/privateTypeIndex.ttl', 'PUT')).toEqual(true)
+        expect(byUrlAndMethod('https://bob.example.com/settings/prefs.ttl', 'PUT')).toEqual(true)
+        expect(byUrlAndMethod('https://bob.example.com/settings/prefs.ttl', 'PATCH')).toEqual(true)
+        expect(byUrlAndMethod('https://bob.example.com/settings/privateTypeIndex.ttl', 'PUT')).toEqual(true)
 
         const createdPublicTypeIndexBody = web['https://bob.example.com/profile/publicTypeIndex.ttl']
         expect(createdPublicTypeIndexBody).toBeDefined()
@@ -223,7 +223,7 @@ describe('TypeIndex logic NEW', () => {
         expect(createdPublicTypeIndexBody).toContain('a solid:TypeIndex ;')
         expect(createdPublicTypeIndexBody).toContain('a solid:ListedDocument.')
 
-        const createdPrivateTypeIndexBody = web['https://bob.example.com/Settings/privateTypeIndex.ttl']
+        const createdPrivateTypeIndexBody = web['https://bob.example.com/settings/privateTypeIndex.ttl']
         expect(createdPrivateTypeIndexBody).toBeDefined()
         expect(createdPrivateTypeIndexBody).toContain('@prefix solid: <http://www.w3.org/ns/solid/terms#>.')
         expect(createdPrivateTypeIndexBody).toContain('<>')
@@ -231,8 +231,8 @@ describe('TypeIndex logic NEW', () => {
         expect(createdPrivateTypeIndexBody).toContain('a solid:UnlistedDocument.')
 
         // New ACL/setup behavior
-        expect(byUrlAndMethod('https://bob.example.com/Settings/', 'PUT')).toEqual(true)
-        expect(byUrlAndMethod('https://bob.example.com/Settings/.acl', 'PUT')).toEqual(true)
+        expect(byUrlAndMethod('https://bob.example.com/settings/', 'PUT')).toEqual(true)
+        expect(byUrlAndMethod('https://bob.example.com/settings/.acl', 'PUT')).toEqual(true)
 
         })
     })

--- a/test/utilityLogic.test.ts
+++ b/test/utilityLogic.test.ts
@@ -95,6 +95,33 @@ describe('utilityLogic', () => {
         })
     })
 
+    describe('loadOrCreateWithContentOnCreate', () => {
+        it('exists', () => {
+            expect(utilityLogic.loadOrCreateWithContentOnCreate).toBeInstanceOf(Function)
+        })
+        it('creates and seeds content when missing', async () => {
+            const suggestion = 'https://bob.example.com/settings/new-index.ttl'
+            const body = [
+                '@prefix solid: <http://www.w3.org/ns/solid/terms#>.',
+                '<>',
+                '  a solid:TypeIndex ;',
+                '  a solid:ListedDocument.'
+            ].join('\n')
+            const created = await utilityLogic.loadOrCreateWithContentOnCreate(sym(suggestion), body)
+
+            expect(created).toEqual(true)
+            expect(web[suggestion]).toEqual(body)
+        })
+        it('does not overwrite existing content', async () => {
+            const existing = AlicePrivateTypeIndex.uri
+            const before = web[existing]
+            const created = await utilityLogic.loadOrCreateWithContentOnCreate(sym(existing), 'NEW')
+
+            expect(created).toEqual(false)
+            expect(web[existing]).toEqual(before)
+        })
+    })
+
     describe('followOrCreateLink', () => {
         it('exists', () => {
             expect(utilityLogic.followOrCreateLink).toBeInstanceOf(Function)

--- a/test/utilityLogic.test.ts
+++ b/test/utilityLogic.test.ts
@@ -152,6 +152,35 @@ describe('utilityLogic', () => {
         })
 
     })
+
+    describe('followOrCreateLinkWithContentOnCreate', () => {
+        it('exists', () => {
+            expect(utilityLogic.followOrCreateLinkWithContentOnCreate).toBeInstanceOf(Function)
+        })
+        it('does not create target doc when link patch fails', async () => {
+            const suggestion = 'https://bob.example.com/settings/prefsSuggestion.ttl'
+            const body = [
+                '@prefix solid: <http://www.w3.org/ns/solid/terms#>.',
+                '<>',
+                '  a solid:TypeIndex ;',
+                '  a solid:ListedDocument.'
+            ].join('\n')
+
+            statustoBeReturned = 403 // Make PATCH fail
+            await expect(
+                utilityLogic.followOrCreateLinkWithContentOnCreate(
+                    bob,
+                    ns.space('preferencesFile'),
+                    sym(suggestion),
+                    bob.doc(),
+                    body
+                )
+            ).rejects.toThrow(WebOperationError)
+
+            expect(web[suggestion]).toBeUndefined()
+        })
+    })
+
 describe('setSinglePeerAccess', () => {
 	beforeEach(() => {
 		fetchMock.mockOnceIf(


### PR DESCRIPTION
Ticket https://github.com/SolidOS/solid-ui/issues/464
The preference file, public type index, and private type index that were getting created were blank, this populates the files as done in the server upon registration for a new account. The Preferences file that was being created also was named Preferences.ttl, while the server creates prefs.ttl so that was also changed to match.

Lastly if the preferences file is missing it also looks for the public and private type indexes. The public type index is written to the webid profile as well as the prefs file, while the private index is only written to prefs as the specification indicates.

**existing functionality: when publicTypeIndex only is missing it creates this under profile and adds link only to WebID profile not preferences** Here is some code where it is looking solely for public index in settings https://github.com/SolidOS/solid-panes/blob/16321184ab8911d704546f1c99321963081ec47b/src/internal/internalPane.ts#L256.